### PR TITLE
Add background worker dispatch method for TUI tasks

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5,6 +5,18 @@ use mem::graph_store::GraphStore;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{channel, Sender, Receiver};
+use std::thread;
+
+/// Background worker task
+pub enum BackgroundTask {
+    NoOp,
+}
+
+/// Background worker result
+pub enum BackgroundResult {
+    NoOpDone,
+}
 
 /// Which field is active in the capture modal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -121,6 +133,9 @@ pub struct App {
     pub blocked_count: usize,
     pub project_count: usize,
     pub assumption_counts: (usize, usize, usize), // (untested, confirmed, invalidated)
+    // Worker channels
+    pub task_tx: Sender<BackgroundTask>,
+    pub result_rx: Receiver<BackgroundResult>,
 }
 
 /// A search result for the fuzzy search overlay.
@@ -134,6 +149,22 @@ pub struct SearchHit {
 
 impl App {
     pub fn new(pkb_root: &Path, db_path: &Path) -> Self {
+        let (task_tx, task_rx) = channel();
+        let (result_tx, result_rx) = channel();
+
+        // Spawn worker thread
+        let _pkb_root_clone = pkb_root.to_path_buf();
+        let _db_path_clone = db_path.to_path_buf();
+        thread::spawn(move || {
+             while let Ok(task) = task_rx.recv() {
+                 match task {
+                     BackgroundTask::NoOp => {
+                         let _ = result_tx.send(BackgroundResult::NoOpDone);
+                     }
+                 }
+             }
+        });
+
         Self {
             pkb_root: pkb_root.to_path_buf(),
             db_path: db_path.to_path_buf(),
@@ -171,6 +202,8 @@ impl App {
             blocked_count: 0,
             project_count: 0,
             assumption_counts: (0, 0, 0),
+            task_tx,
+            result_rx,
         }
     }
 
@@ -829,6 +862,21 @@ impl App {
 
         self.reparent_mode = false;
         self.reparent_node_id = None;
+    }
+    pub fn dispatch_worker(&self, task: BackgroundTask) {
+        if let Err(e) = self.task_tx.send(task) {
+            eprintln!("Failed to dispatch worker task: {}", e);
+        }
+    }
+
+    pub fn poll_worker(&mut self) {
+        while let Ok(result) = self.result_rx.try_recv() {
+            match result {
+                BackgroundResult::NoOpDone => {
+                    // Handle result
+                }
+            }
+        }
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -41,6 +41,7 @@ pub fn run(pkb_root: &Path, db_path: &Path) -> Result<()> {
 
 fn run_event_loop(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>, app: &mut App) -> Result<()> {
     loop {
+        app.poll_worker();
         terminal.draw(|frame| views::render(frame, app))?;
 
         if event::poll(Duration::from_millis(100))? {


### PR DESCRIPTION
This PR adds a mechanism to dispatch background tasks from the TUI. It introduces `BackgroundTask` and `BackgroundResult` enums, updates `App` struct with channels, spawns a background thread in `App::new`, and adds `dispatch_worker` and `poll_worker` methods. The worker is polled in the main event loop.

---
*PR created automatically by Jules for task [11028941231657918894](https://jules.google.com/task/11028941231657918894) started by @nicsuzor*