### PR TITLE
feat: allow pkb server to start with stale index

### DIFF
--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -26,6 +26,7 @@ pub struct PkbSearchServer {
     pkb_root: PathBuf,
     db_path: PathBuf,
     graph: Arc<RwLock<GraphStore>>,
+    stale_count: usize,
 }
 
 impl PkbSearchServer {
@@ -42,7 +43,13 @@ impl PkbSearchServer {
             pkb_root,
             db_path,
             graph,
+            stale_count: 0,
         }
+    }
+
+    pub fn with_stale_count(mut self, count: usize) -> Self {
+        self.stale_count = count;
+        self
     }
 
     fn resolve_path(&self, path_str: &str) -> PathBuf {
@@ -2428,17 +2435,27 @@ impl ServerHandler for PkbSearchServer {
                 name: "pkb".into(),
                 version: env!("CARGO_PKG_VERSION").into(),
             },
-            instructions: Some(
-                "PKB Search — semantic search + task graph over personal knowledge base. \
-                 24 tools: search, get_document, list_documents, \
-                 task_search, get_network_metrics, create_task, create_memory, \
-                 create, append, delete, complete_task, list_tasks, \
-                 get_task, update_task, retrieve_memory, search_by_tag, \
-                 list_memories, delete_memory, decompose_task, \
-                 get_dependency_tree, get_task_children, \
-                 pkb_context, pkb_trace, pkb_orphans."
-                    .to_string(),
-            ),
+            instructions: Some({
+                let mut instructions = String::from(
+                    "PKB Search — semantic search + task graph over personal knowledge base. \
+                     24 tools: search, get_document, list_documents, \
+                     task_search, get_network_metrics, create_task, create_memory, \
+                     create, append, delete, complete_task, list_tasks, \
+                     get_task, update_task, retrieve_memory, search_by_tag, \
+                     list_memories, delete_memory, decompose_task, \
+                     get_dependency_tree, get_task_children, \
+                     pkb_context, pkb_trace, pkb_orphans.",
+                );
+                if self.stale_count > 0 {
+                    instructions.push_str(&format!(
+                        " WARNING: Index is stale — {} document(s) need re-indexing. \
+                         Search results may be incomplete or outdated. \
+                         Run `aops reindex` to update.",
+                        self.stale_count
+                    ));
+                }
+                instructions
+            }),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,7 @@
 //! markdown files. Provides an MCP interface via stdio transport.
 //!
 //! Indexing is handled externally by `aops reindex`. This server only reads
-//! the pre-built vector store and errors out if the index is stale.
+//! the pre-built vector store and warns on startup if the index is stale.
 
 use mem::{embeddings, graph_store, mcp_server, vectordb};
 
@@ -72,16 +72,16 @@ async fn main() -> Result<()> {
         embedder.dimension(),
     )?));
 
-    // Check index freshness — fail fast if stale
+    // Check index freshness — warn if stale but continue
     eprintln!("   Checking index freshness...");
     let stale_count = mem::check_index_staleness(&pkb_root, &store);
-    if stale_count > 0 {
-        eprintln!("   ✗ Index is stale: {stale_count} document(s) need re-indexing.");
-        eprintln!("   Run `aops reindex` before starting the server.");
-        std::process::exit(1);
-    }
     let total = store.read().len();
-    eprintln!("   ✓ Index is fresh ({total} documents)");
+    if stale_count > 0 {
+        eprintln!("   ⚠ Index is stale: {stale_count} document(s) need re-indexing.");
+        eprintln!("   Run `aops reindex` to update the search index.");
+    } else {
+        eprintln!("   ✓ Index is fresh ({total} documents)");
+    }
 
     // Build graph store
     eprintln!("   Building knowledge graph...");
@@ -101,7 +101,8 @@ async fn main() -> Result<()> {
         pkb_root.clone(),
         db_path.clone(),
         graph.clone(),
-    );
+    )
+    .with_stale_count(stale_count);
 
     let service = server.serve(rmcp::transport::stdio()).await?;
     eprintln!("   ✓ MCP server ready");


### PR DESCRIPTION
## Summary
- Removed `std::process::exit(1)` when the vector index is stale — server now starts and warns instead
- Stale count is passed to the MCP server and included in the `instructions` field sent to clients on initialization
- Clients see a warning reminding them to run `aops reindex` when the index is out of date

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all 88 tests pass, no regressions
- [ ] Manual: start `pkb` with a stale/missing index and verify it starts with a warning
- [ ] Manual: verify MCP client receives the stale warning in instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)