### PR TITLE
feat: implement batch graph operations (Phase 1)

### DIFF
--- a/src/batch_ops/duplicates.rs
+++ b/src/batch_ops/duplicates.rs
@@ -1,0 +1,572 @@
+//! `find_duplicates` and `batch_merge` — duplicate detection and resolution.
+
+use super::{BatchContext, BatchSummary, TaskAction, TaskError};
+use crate::distance::cosine_similarity;
+use crate::graph::GraphNode;
+use crate::graph_store::GraphStore;
+use crate::vectordb::VectorStore;
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+/// A cluster of potentially duplicate tasks.
+#[derive(Debug, Clone, Serialize)]
+pub struct DuplicateCluster {
+    /// Confidence score (0.0 - 1.0)
+    pub confidence: f64,
+    /// Suggested canonical task ID (oldest, most connected, most content)
+    pub canonical: String,
+    /// All tasks in the cluster
+    pub tasks: Vec<DuplicateEntry>,
+    /// Similarity scores
+    pub similarity_scores: SimilarityScores,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DuplicateEntry {
+    pub id: String,
+    pub title: String,
+    pub project: Option<String>,
+    pub created: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SimilarityScores {
+    pub title: f64,
+    pub semantic: f64,
+}
+
+/// Result of find_duplicates.
+#[derive(Debug, Clone, Serialize)]
+pub struct DuplicateReport {
+    pub clusters: Vec<DuplicateCluster>,
+    pub total_clusters: usize,
+    pub total_duplicates: usize,
+}
+
+/// Duplicate detection mode.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DuplicateMode {
+    Title,
+    Semantic,
+    Both,
+}
+
+impl DuplicateMode {
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "title" => DuplicateMode::Title,
+            "semantic" => DuplicateMode::Semantic,
+            _ => DuplicateMode::Both,
+        }
+    }
+}
+
+/// Find potential duplicate tasks using title similarity and/or semantic embedding similarity.
+pub fn find_duplicates(
+    graph: &GraphStore,
+    store: &VectorStore,
+    filters: &super::filters::FilterSet,
+    mode: DuplicateMode,
+    title_threshold: f64,
+    semantic_threshold: f64,
+) -> DuplicateReport {
+    let matched_ids = filters.resolve(graph);
+
+    // Collect nodes for comparison
+    let nodes: Vec<&GraphNode> = matched_ids
+        .iter()
+        .filter_map(|id| graph.get_node(id))
+        .filter(|n| !crate::graph::is_completed(n.status.as_deref()))
+        .collect();
+
+    if nodes.len() < 2 {
+        return DuplicateReport {
+            clusters: vec![],
+            total_clusters: 0,
+            total_duplicates: 0,
+        };
+    }
+
+    // Build embedding lookup: node_id -> average embedding
+    let embeddings: HashMap<String, Vec<f32>> = if mode != DuplicateMode::Title {
+        build_embedding_map(&nodes, store)
+    } else {
+        HashMap::new()
+    };
+
+    // Pairwise comparison
+    let mut pairs: Vec<(usize, usize, f64, f64)> = Vec::new(); // (i, j, title_sim, semantic_sim)
+
+    for i in 0..nodes.len() {
+        for j in (i + 1)..nodes.len() {
+            let title_sim = if mode != DuplicateMode::Semantic {
+                title_similarity(&nodes[i].label, &nodes[j].label)
+            } else {
+                0.0
+            };
+
+            let semantic_sim = if mode != DuplicateMode::Title {
+                match (embeddings.get(&nodes[i].id), embeddings.get(&nodes[j].id)) {
+                    (Some(a), Some(b)) => cosine_similarity(a, b) as f64,
+                    _ => 0.0,
+                }
+            } else {
+                0.0
+            };
+
+            let is_duplicate = match mode {
+                DuplicateMode::Title => title_sim >= title_threshold,
+                DuplicateMode::Semantic => semantic_sim >= semantic_threshold,
+                DuplicateMode::Both => {
+                    title_sim >= title_threshold || semantic_sim >= semantic_threshold
+                }
+            };
+
+            if is_duplicate {
+                pairs.push((i, j, title_sim, semantic_sim));
+            }
+        }
+    }
+
+    // Build clusters via union-find
+    let clusters = build_clusters(&nodes, &pairs, title_threshold, semantic_threshold);
+
+    let total_duplicates: usize = clusters.iter().map(|c| c.tasks.len() - 1).sum();
+
+    DuplicateReport {
+        total_clusters: clusters.len(),
+        total_duplicates,
+        clusters,
+    }
+}
+
+/// Merge duplicate tasks into a canonical task.
+pub fn batch_merge(
+    graph: &GraphStore,
+    pkb_root: &Path,
+    canonical_id: &str,
+    merge_ids: &[String],
+    dry_run: bool,
+) -> BatchSummary {
+    let mut summary = BatchSummary::new("merge", dry_run);
+
+    // Validate canonical exists
+    let canonical = match graph.resolve(canonical_id) {
+        Some(n) => n,
+        None => {
+            summary.errors.push(TaskError {
+                id: canonical_id.to_string(),
+                error: "canonical task not found".to_string(),
+            });
+            return summary;
+        }
+    };
+    let canonical_id = canonical.id.clone();
+    summary.matched = merge_ids.len() + 1; // include canonical
+
+    let mut ctx = BatchContext::new(graph, pkb_root);
+
+    // Collect data from merged tasks
+    let mut all_tags: HashSet<String> = canonical.tags.iter().cloned().collect();
+    let mut all_depends_on: HashSet<String> = canonical.depends_on.iter().cloned().collect();
+    let best_priority = canonical.priority.unwrap_or(2);
+    let mut children_to_reparent: Vec<String> = Vec::new();
+    let mut backlinks_to_update: Vec<(String, String)> = Vec::new(); // (node_id, field) to repoint
+
+    for merge_id in merge_ids {
+        let node = match graph.resolve(merge_id) {
+            Some(n) => n,
+            None => {
+                summary.errors.push(TaskError {
+                    id: merge_id.clone(),
+                    error: "task not found".to_string(),
+                });
+                continue;
+            }
+        };
+
+        // Collect tags, deps
+        all_tags.extend(node.tags.iter().cloned());
+        all_depends_on.extend(node.depends_on.iter().cloned());
+
+        // Collect children to reparent
+        children_to_reparent.extend(node.children.iter().cloned());
+
+        // Find backlinks: anything that references this merged task
+        for other in graph.nodes() {
+            if other.id == canonical_id || other.id == node.id {
+                continue;
+            }
+            if other.parent.as_deref() == Some(&node.id) {
+                backlinks_to_update.push((other.id.clone(), "parent".to_string()));
+            }
+            if other.depends_on.contains(&node.id) {
+                backlinks_to_update.push((other.id.clone(), "depends_on".to_string()));
+            }
+        }
+
+        if dry_run {
+            summary.changed += 1;
+            summary.tasks.push(TaskAction {
+                id: node.id.clone(),
+                title: node.label.clone(),
+                action: "would_merge".to_string(),
+                detail: Some(format!("→ {canonical_id}")),
+                old_value: None,
+                new_value: None,
+            });
+            continue;
+        }
+
+        // Archive merged task with superseded_by
+        let mut updates = HashMap::new();
+        updates.insert(
+            "status".to_string(),
+            serde_json::Value::String("done".to_string()),
+        );
+        updates.insert(
+            "superseded_by".to_string(),
+            serde_json::Value::String(canonical_id.clone()),
+        );
+
+        match ctx.update_task(&node.id, updates) {
+            Ok(()) => {
+                summary.changed += 1;
+                summary.tasks.push(TaskAction {
+                    id: node.id.clone(),
+                    title: node.label.clone(),
+                    action: "merged".to_string(),
+                    detail: Some(format!("archived, superseded by {canonical_id}")),
+                    old_value: None,
+                    new_value: None,
+                });
+            }
+            Err(e) => {
+                summary.errors.push(TaskError {
+                    id: node.id.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // Remove self-references from deps
+    all_depends_on.remove(&canonical_id);
+    for merge_id in merge_ids {
+        all_depends_on.remove(merge_id);
+    }
+
+    if dry_run {
+        // Report what would happen to canonical
+        summary.tasks.push(TaskAction {
+            id: canonical_id,
+            title: canonical.label.clone(),
+            action: "canonical".to_string(),
+            detail: Some("would receive merged tags/deps/children".to_string()),
+            old_value: None,
+            new_value: None,
+        });
+        return summary;
+    }
+
+    // Update canonical with merged data
+    let mut canonical_updates = HashMap::new();
+
+    let tags_vec: Vec<String> = all_tags.into_iter().collect();
+    canonical_updates.insert(
+        "tags".to_string(),
+        serde_json::Value::Array(tags_vec.into_iter().map(serde_json::Value::String).collect()),
+    );
+
+    if !all_depends_on.is_empty() {
+        let deps_vec: Vec<String> = all_depends_on.into_iter().collect();
+        canonical_updates.insert(
+            "depends_on".to_string(),
+            serde_json::Value::Array(deps_vec.into_iter().map(serde_json::Value::String).collect()),
+        );
+    }
+
+    // Keep highest priority (lowest number)
+    let final_priority = merge_ids
+        .iter()
+        .filter_map(|id| graph.resolve(id))
+        .filter_map(|n| n.priority)
+        .chain(std::iter::once(best_priority))
+        .min()
+        .unwrap_or(2);
+    canonical_updates.insert(
+        "priority".to_string(),
+        serde_json::Value::Number(final_priority.into()),
+    );
+
+    if let Err(e) = ctx.update_task(&canonical_id, canonical_updates) {
+        summary.errors.push(TaskError {
+            id: canonical_id.clone(),
+            error: format!("failed to update canonical: {e}"),
+        });
+    } else {
+        summary.tasks.push(TaskAction {
+            id: canonical_id.clone(),
+            title: canonical.label.clone(),
+            action: "canonical".to_string(),
+            detail: Some("updated with merged tags/deps".to_string()),
+            old_value: None,
+            new_value: None,
+        });
+    }
+
+    // Reparent children of merged tasks
+    for child_id in &children_to_reparent {
+        let mut updates = HashMap::new();
+        updates.insert(
+            "parent".to_string(),
+            serde_json::Value::String(canonical_id.clone()),
+        );
+        if let Err(e) = ctx.update_task(child_id, updates) {
+            summary.errors.push(TaskError {
+                id: child_id.clone(),
+                error: format!("failed to reparent child: {e}"),
+            });
+        }
+    }
+
+    // Update backlinks
+    for (node_id, field) in &backlinks_to_update {
+        if let Some(node) = graph.get_node(node_id) {
+            let mut updates = HashMap::new();
+            match field.as_str() {
+                "parent" => {
+                    updates.insert(
+                        "parent".to_string(),
+                        serde_json::Value::String(canonical_id.clone()),
+                    );
+                }
+                "depends_on" => {
+                    let new_deps: Vec<String> = node
+                        .depends_on
+                        .iter()
+                        .map(|d| {
+                            if merge_ids.contains(d) {
+                                canonical_id.clone()
+                            } else {
+                                d.clone()
+                            }
+                        })
+                        .collect();
+                    updates.insert(
+                        "depends_on".to_string(),
+                        serde_json::Value::Array(
+                            new_deps.into_iter().map(serde_json::Value::String).collect(),
+                        ),
+                    );
+                }
+                _ => {}
+            }
+            let _ = ctx.update_task(node_id, updates);
+        }
+    }
+
+    summary
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/// Compute Jaccard similarity on word sets (normalized, lowercased).
+fn title_similarity(a: &str, b: &str) -> f64 {
+    let a_lower = a.to_lowercase();
+    let b_lower = b.to_lowercase();
+    let words_a: HashSet<&str> = a_lower.split_whitespace().collect();
+    let words_b: HashSet<&str> = b_lower.split_whitespace().collect();
+
+    if words_a.is_empty() && words_b.is_empty() {
+        return 1.0;
+    }
+
+    let intersection = words_a.intersection(&words_b).count();
+    let union = words_a.union(&words_b).count();
+
+    if union == 0 {
+        0.0
+    } else {
+        intersection as f64 / union as f64
+    }
+}
+
+/// Build average embedding for each node from the vector store.
+fn build_embedding_map(nodes: &[&GraphNode], store: &VectorStore) -> HashMap<String, Vec<f32>> {
+    let mut map = HashMap::new();
+
+    for node in nodes {
+        let path_str = node.path.to_string_lossy().to_string();
+
+        // Try exact path, then try with/without leading prefix
+        let entry = store
+            .get_entry(&path_str)
+            .or_else(|| {
+                // Try stripping leading path components
+                let stripped = path_str.strip_prefix("tasks/").unwrap_or(&path_str);
+                store.get_entry(stripped)
+            });
+
+        if let Some(entry) = entry {
+            if let Some(avg) = average_embedding(&entry.chunk_embeddings) {
+                map.insert(node.id.clone(), avg);
+            }
+        }
+    }
+
+    map
+}
+
+/// Average multiple chunk embeddings into one vector.
+fn average_embedding(embeddings: &[Vec<f32>]) -> Option<Vec<f32>> {
+    if embeddings.is_empty() {
+        return None;
+    }
+    let dim = embeddings[0].len();
+    let mut avg = vec![0.0f32; dim];
+    let n = embeddings.len() as f32;
+
+    for emb in embeddings {
+        for (i, v) in emb.iter().enumerate() {
+            if i < dim {
+                avg[i] += v / n;
+            }
+        }
+    }
+    Some(avg)
+}
+
+/// Build duplicate clusters from pairwise matches via union-find.
+fn build_clusters(
+    nodes: &[&GraphNode],
+    pairs: &[(usize, usize, f64, f64)],
+    _title_threshold: f64,
+    _semantic_threshold: f64,
+) -> Vec<DuplicateCluster> {
+    // Simple union-find
+    let n = nodes.len();
+    let mut parent: Vec<usize> = (0..n).collect();
+
+    fn find(parent: &mut Vec<usize>, x: usize) -> usize {
+        if parent[x] != x {
+            parent[x] = find(parent, parent[x]);
+        }
+        parent[x]
+    }
+
+    fn union(parent: &mut Vec<usize>, x: usize, y: usize) {
+        let rx = find(parent, x);
+        let ry = find(parent, y);
+        if rx != ry {
+            parent[ry] = rx;
+        }
+    }
+
+    for &(i, j, _, _) in pairs {
+        union(&mut parent, i, j);
+    }
+
+    // Group by root
+    let mut groups: HashMap<usize, Vec<usize>> = HashMap::new();
+    for i in 0..n {
+        let root = find(&mut parent, i);
+        groups.entry(root).or_default().push(i);
+    }
+
+    // Build clusters (only groups with >1 member)
+    let mut clusters: Vec<DuplicateCluster> = groups
+        .into_values()
+        .filter(|members| members.len() > 1)
+        .map(|members| {
+            // Find best pair scores for this cluster
+            let mut best_title = 0.0f64;
+            let mut best_semantic = 0.0f64;
+            for &(i, j, ts, ss) in pairs {
+                if members.contains(&i) && members.contains(&j) {
+                    best_title = best_title.max(ts);
+                    best_semantic = best_semantic.max(ss);
+                }
+            }
+
+            let confidence = best_title.max(best_semantic);
+
+            // Select canonical: prefer oldest, then most connected, then most content
+            let canonical_idx = *members
+                .iter()
+                .min_by(|&&a, &&b| {
+                    // Prefer oldest
+                    let date_cmp = nodes[a]
+                        .created
+                        .cmp(&nodes[b].created);
+                    // Then most children
+                    let children_cmp = nodes[b]
+                        .children
+                        .len()
+                        .cmp(&nodes[a].children.len());
+                    // Then most content
+                    let content_cmp = nodes[b]
+                        .word_count
+                        .cmp(&nodes[a].word_count);
+                    date_cmp.then(children_cmp).then(content_cmp)
+                })
+                .unwrap();
+
+            let tasks: Vec<DuplicateEntry> = members
+                .iter()
+                .map(|&idx| DuplicateEntry {
+                    id: nodes[idx].id.clone(),
+                    title: nodes[idx].label.clone(),
+                    project: nodes[idx].project.clone(),
+                    created: nodes[idx].created.clone(),
+                })
+                .collect();
+
+            DuplicateCluster {
+                confidence,
+                canonical: nodes[canonical_idx].id.clone(),
+                tasks,
+                similarity_scores: SimilarityScores {
+                    title: best_title,
+                    semantic: best_semantic,
+                },
+            }
+        })
+        .collect();
+
+    clusters.sort_by(|a, b| b.confidence.partial_cmp(&a.confidence).unwrap_or(std::cmp::Ordering::Equal));
+    clusters
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_title_similarity_identical() {
+        assert!((title_similarity("Write spec for analyst skill", "Write spec for analyst skill") - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_title_similarity_high() {
+        let sim = title_similarity(
+            "Write spec for analyst skill",
+            "Write spec for the analyst skill",
+        );
+        assert!(sim > 0.7, "Expected >0.7, got {sim}");
+    }
+
+    #[test]
+    fn test_title_similarity_low() {
+        let sim = title_similarity("Fix memory leak in TUI", "Write spec for analyst");
+        assert!(sim < 0.3, "Expected <0.3, got {sim}");
+    }
+
+    #[test]
+    fn test_average_embedding() {
+        let embs = vec![vec![1.0, 2.0, 3.0], vec![3.0, 2.0, 1.0]];
+        let avg = average_embedding(&embs).unwrap();
+        assert_eq!(avg, vec![2.0, 2.0, 2.0]);
+    }
+}

--- a/src/batch_ops/epics.rs
+++ b/src/batch_ops/epics.rs
@@ -1,0 +1,200 @@
+//! `batch_create_epics` — create epic containers and reparent tasks under them.
+
+use super::{BatchSummary, TaskAction, TaskError};
+use crate::document_crud::{self, DocumentFields};
+use crate::graph_store::GraphStore;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Definition of an epic to create.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EpicDef {
+    pub title: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub priority: Option<i32>,
+    pub task_ids: Vec<String>,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+/// Create multiple epics and reparent existing tasks under them.
+pub fn batch_create_epics(
+    graph: &GraphStore,
+    pkb_root: &Path,
+    parent: Option<&str>,
+    project: Option<&str>,
+    epics: &[EpicDef],
+    dry_run: bool,
+) -> BatchSummary {
+    let mut summary = BatchSummary::new("create_epics", dry_run);
+    summary.matched = epics.len();
+
+    // Validate parent if specified
+    if let Some(parent_id) = parent {
+        if graph.resolve(parent_id).is_none() {
+            summary.errors.push(TaskError {
+                id: parent_id.to_string(),
+                error: "parent not found in graph".to_string(),
+            });
+            return summary;
+        }
+    }
+
+    for epic_def in epics {
+        // Validate task_ids exist
+        let mut valid_task_ids = Vec::new();
+        for task_id in &epic_def.task_ids {
+            match graph.resolve(task_id) {
+                Some(n) => valid_task_ids.push(n.id.clone()),
+                None => {
+                    summary.errors.push(TaskError {
+                        id: task_id.clone(),
+                        error: format!("task not found (referenced in epic '{}')", epic_def.title),
+                    });
+                }
+            }
+        }
+
+        if dry_run {
+            summary.changed += 1;
+            summary.tasks.push(TaskAction {
+                id: epic_def.id.clone().unwrap_or_else(|| "auto".to_string()),
+                title: epic_def.title.clone(),
+                action: "would_create_epic".to_string(),
+                detail: Some(format!("{} tasks to reparent", valid_task_ids.len())),
+                old_value: None,
+                new_value: None,
+            });
+            for tid in &valid_task_ids {
+                let node = graph.get_node(tid);
+                summary.tasks.push(TaskAction {
+                    id: tid.clone(),
+                    title: node.map(|n| n.label.clone()).unwrap_or_default(),
+                    action: "would_reparent".to_string(),
+                    detail: Some(format!("→ {}", epic_def.title)),
+                    old_value: node.and_then(|n| n.parent.clone()),
+                    new_value: epic_def.id.clone(),
+                });
+            }
+            continue;
+        }
+
+        // Create the epic
+        let fields = DocumentFields {
+            title: epic_def.title.clone(),
+            doc_type: "epic".to_string(),
+            id: epic_def.id.clone(),
+            priority: epic_def.priority,
+            parent: parent.map(String::from),
+            project: project.map(String::from),
+            depends_on: epic_def.depends_on.clone(),
+            body: epic_def.body.clone(),
+            ..Default::default()
+        };
+
+        let epic_path = match document_crud::create_document(pkb_root, fields) {
+            Ok(path) => path,
+            Err(e) => {
+                summary.errors.push(TaskError {
+                    id: epic_def.id.clone().unwrap_or_default(),
+                    error: format!("failed to create epic: {e}"),
+                });
+                continue;
+            }
+        };
+
+        // Read back the epic's ID from the file
+        let epic_id = read_id_from_file(&epic_path).unwrap_or_else(|| {
+            epic_path
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default()
+        });
+
+        summary.changed += 1;
+        summary.tasks.push(TaskAction {
+            id: epic_id.clone(),
+            title: epic_def.title.clone(),
+            action: "created_epic".to_string(),
+            detail: Some(format!("at {}", epic_path.display())),
+            old_value: None,
+            new_value: None,
+        });
+
+        // Reparent tasks under the new epic
+        for task_id in &valid_task_ids {
+            let mut updates = HashMap::new();
+            updates.insert(
+                "parent".to_string(),
+                serde_json::Value::String(epic_id.clone()),
+            );
+            if let Some(proj) = project {
+                updates.insert(
+                    "project".to_string(),
+                    serde_json::Value::String(proj.to_string()),
+                );
+            }
+
+            let node = graph.get_node(task_id);
+            let abs_path = node.map(|n| {
+                if n.path.is_absolute() {
+                    n.path.clone()
+                } else {
+                    pkb_root.join(&n.path)
+                }
+            });
+
+            match abs_path {
+                Some(path) if path.exists() => {
+                    match document_crud::update_document(&path, updates) {
+                        Ok(()) => {
+                            summary.tasks.push(TaskAction {
+                                id: task_id.clone(),
+                                title: node.map(|n| n.label.clone()).unwrap_or_default(),
+                                action: "reparented".to_string(),
+                                detail: Some(format!("→ {epic_id}")),
+                                old_value: node.and_then(|n| n.parent.clone()),
+                                new_value: Some(epic_id.clone()),
+                            });
+                        }
+                        Err(e) => {
+                            summary.errors.push(TaskError {
+                                id: task_id.clone(),
+                                error: format!("reparent failed: {e}"),
+                            });
+                        }
+                    }
+                }
+                _ => {
+                    summary.errors.push(TaskError {
+                        id: task_id.clone(),
+                        error: "file not found on disk".to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    summary
+}
+
+/// Read the `id` field from a freshly-created frontmatter file.
+fn read_id_from_file(path: &Path) -> Option<String> {
+    use gray_matter::engine::YAML;
+    use gray_matter::Matter;
+
+    let content = std::fs::read_to_string(path).ok()?;
+    let matter = Matter::<YAML>::new();
+    let result = matter.parse(&content);
+
+    result
+        .data
+        .as_ref()
+        .and_then(|d| d.deserialize::<serde_json::Value>().ok())
+        .and_then(|v| v.get("id").and_then(|id| id.as_str().map(String::from)))
+}

--- a/src/batch_ops/filters.rs
+++ b/src/batch_ops/filters.rs
@@ -1,0 +1,407 @@
+//! Shared filter DSL for batch operations.
+//!
+//! [`FilterSet`] provides composable, AND-logic filters over the task graph.
+//! Within a single filter field, multiple values use OR logic (e.g. multiple IDs).
+
+use crate::graph::GraphNode;
+use crate::graph_store::GraphStore;
+use chrono::{NaiveDate, Utc};
+use std::collections::HashSet;
+
+/// Composable filter set for selecting tasks from the graph.
+///
+/// All filters are AND-composed: a task must match every non-None filter.
+/// Multiple values within a single field (e.g. `ids`, `tags`) use OR logic.
+#[derive(Debug, Clone, Default)]
+pub struct FilterSet {
+    /// Explicit task IDs (flexible resolution)
+    pub ids: Option<Vec<String>>,
+    /// Match project field
+    pub project: Option<String>,
+    /// Direct children of parent
+    pub parent: Option<String>,
+    /// All descendants (recursive)
+    pub subtree: Option<String>,
+    /// Match status
+    pub status: Option<String>,
+    /// Exact priority match
+    pub priority: Option<i32>,
+    /// Priority >= N
+    pub priority_gte: Option<i32>,
+    /// Has ALL listed tags
+    pub tags: Option<Vec<String>>,
+    /// Match document type
+    pub doc_type: Option<String>,
+    /// Days since `created`
+    pub older_than_days: Option<u64>,
+    /// Days since `modified`
+    pub stale_days: Option<u64>,
+    /// No parent and no project
+    pub orphan: Option<bool>,
+    /// Substring match on title (case-insensitive)
+    pub title_contains: Option<String>,
+    /// Match complexity tag
+    pub complexity: Option<String>,
+    /// File path contains directory
+    pub directory: Option<String>,
+    /// Downstream weight >= N
+    pub weight_gte: Option<u32>,
+}
+
+impl FilterSet {
+    /// Returns true if no filters are set.
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_none()
+            && self.project.is_none()
+            && self.parent.is_none()
+            && self.subtree.is_none()
+            && self.status.is_none()
+            && self.priority.is_none()
+            && self.priority_gte.is_none()
+            && self.tags.is_none()
+            && self.doc_type.is_none()
+            && self.older_than_days.is_none()
+            && self.stale_days.is_none()
+            && self.orphan.is_none()
+            && self.title_contains.is_none()
+            && self.complexity.is_none()
+            && self.directory.is_none()
+            && self.weight_gte.is_none()
+    }
+
+    /// Resolve against graph, return matching node IDs.
+    pub fn resolve(&self, graph: &GraphStore) -> Vec<String> {
+        // Start with candidate set
+        let candidates: Vec<&GraphNode> = if let Some(ref ids) = self.ids {
+            // Explicit IDs — resolve each flexibly
+            ids.iter()
+                .filter_map(|id| graph.resolve(id))
+                .collect()
+        } else {
+            // All nodes with a task_id (actionable documents)
+            graph.nodes().filter(|n| n.task_id.is_some()).collect()
+        };
+
+        // Collect subtree IDs if needed
+        let subtree_ids: Option<HashSet<String>> = self.subtree.as_ref().map(|root_id| {
+            collect_subtree_ids(graph, root_id)
+        });
+
+        let now = Utc::now().date_naive();
+
+        candidates
+            .into_iter()
+            .filter(|node| self.matches_node(node, graph, subtree_ids.as_ref(), now))
+            .map(|node| node.id.clone())
+            .collect()
+    }
+
+    /// Human-readable description of the active filters.
+    pub fn describe(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(ref ids) = self.ids {
+            parts.push(format!("ids=[{}]", ids.join(", ")));
+        }
+        if let Some(ref p) = self.project {
+            parts.push(format!("project={p}"));
+        }
+        if let Some(ref p) = self.parent {
+            parts.push(format!("parent={p}"));
+        }
+        if let Some(ref s) = self.subtree {
+            parts.push(format!("subtree={s}"));
+        }
+        if let Some(ref s) = self.status {
+            parts.push(format!("status={s}"));
+        }
+        if let Some(p) = self.priority {
+            parts.push(format!("priority={p}"));
+        }
+        if let Some(p) = self.priority_gte {
+            parts.push(format!("priority>={p}"));
+        }
+        if let Some(ref t) = self.tags {
+            parts.push(format!("tags=[{}]", t.join(", ")));
+        }
+        if let Some(ref t) = self.doc_type {
+            parts.push(format!("type={t}"));
+        }
+        if let Some(d) = self.older_than_days {
+            parts.push(format!("older_than={d}d"));
+        }
+        if let Some(d) = self.stale_days {
+            parts.push(format!("stale={d}d"));
+        }
+        if self.orphan == Some(true) {
+            parts.push("orphan=true".to_string());
+        }
+        if let Some(ref t) = self.title_contains {
+            parts.push(format!("title_contains=\"{t}\""));
+        }
+        if let Some(ref c) = self.complexity {
+            parts.push(format!("complexity={c}"));
+        }
+        if let Some(ref d) = self.directory {
+            parts.push(format!("directory={d}"));
+        }
+        if let Some(w) = self.weight_gte {
+            parts.push(format!("weight>={w}"));
+        }
+        if parts.is_empty() {
+            "all tasks".to_string()
+        } else {
+            parts.join(", ")
+        }
+    }
+
+    /// Check if a single node matches all active filters.
+    fn matches_node(
+        &self,
+        node: &GraphNode,
+        graph: &GraphStore,
+        subtree_ids: Option<&HashSet<String>>,
+        now: NaiveDate,
+    ) -> bool {
+        // Project filter
+        if let Some(ref project) = self.project {
+            if node.project.as_deref() != Some(project) {
+                return false;
+            }
+        }
+
+        // Parent filter (direct children only)
+        if let Some(ref parent_id) = self.parent {
+            let parent_node = graph.resolve(parent_id);
+            let parent_canonical_id = parent_node.map(|n| n.id.as_str());
+            if node.parent.as_deref() != parent_canonical_id {
+                return false;
+            }
+        }
+
+        // Subtree filter
+        if let Some(ref ids) = subtree_ids {
+            if !ids.contains(&node.id) {
+                return false;
+            }
+        }
+
+        // Status filter
+        if let Some(ref status) = self.status {
+            if node.status.as_deref() != Some(status.as_str()) {
+                return false;
+            }
+        }
+
+        // Priority exact
+        if let Some(priority) = self.priority {
+            if node.priority != Some(priority) {
+                return false;
+            }
+        }
+
+        // Priority gte
+        if let Some(priority_gte) = self.priority_gte {
+            match node.priority {
+                Some(p) if p >= priority_gte => {}
+                _ => return false,
+            }
+        }
+
+        // Tags (must have ALL listed tags)
+        if let Some(ref tags) = self.tags {
+            for tag in tags {
+                if !node.tags.contains(tag) {
+                    return false;
+                }
+            }
+        }
+
+        // Document type
+        if let Some(ref doc_type) = self.doc_type {
+            if node.node_type.as_deref() != Some(doc_type.as_str()) {
+                return false;
+            }
+        }
+
+        // Older than N days (based on created date)
+        if let Some(older_than) = self.older_than_days {
+            if !is_older_than(node.created.as_deref(), now, older_than) {
+                return false;
+            }
+        }
+
+        // Stale N days (based on modified date)
+        if let Some(stale) = self.stale_days {
+            let date_str = node.modified.as_deref().or(node.created.as_deref());
+            if !is_older_than(date_str, now, stale) {
+                return false;
+            }
+        }
+
+        // Orphan: no parent AND no project
+        if self.orphan == Some(true) {
+            if node.parent.is_some() || node.project.is_some() {
+                return false;
+            }
+        }
+
+        // Title contains (case-insensitive)
+        if let Some(ref needle) = self.title_contains {
+            let label_lower = node.label.to_lowercase();
+            if !label_lower.contains(&needle.to_lowercase()) {
+                return false;
+            }
+        }
+
+        // Complexity
+        if let Some(ref complexity) = self.complexity {
+            if node.complexity.as_deref() != Some(complexity.as_str()) {
+                return false;
+            }
+        }
+
+        // Directory filter (path contains)
+        if let Some(ref dir) = self.directory {
+            let path_str = node.path.to_string_lossy();
+            if !path_str.contains(dir.as_str()) {
+                return false;
+            }
+        }
+
+        // Downstream weight >= N
+        if let Some(weight_gte) = self.weight_gte {
+            if node.downstream_weight < weight_gte as f64 {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+/// Parse a FilterSet from MCP JSON arguments.
+pub fn parse_filter_set(args: &serde_json::Value) -> FilterSet {
+    FilterSet {
+        ids: args.get("ids").and_then(|v| {
+            v.as_array().map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+        }),
+        project: args.get("project").and_then(|v| v.as_str().map(String::from)),
+        parent: args.get("parent").and_then(|v| v.as_str().map(String::from)),
+        subtree: args.get("subtree").and_then(|v| v.as_str().map(String::from)),
+        status: args.get("status").and_then(|v| v.as_str().map(String::from)),
+        priority: args.get("priority").and_then(|v| v.as_i64().map(|n| n as i32)),
+        priority_gte: args.get("priority_gte").and_then(|v| v.as_i64().map(|n| n as i32)),
+        tags: args.get("tags").and_then(|v| {
+            v.as_array().map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+        }),
+        doc_type: args.get("type").and_then(|v| v.as_str().map(String::from)),
+        older_than_days: args.get("older_than_days").and_then(|v| v.as_u64()),
+        stale_days: args.get("stale_days").and_then(|v| v.as_u64()),
+        orphan: args.get("orphan").and_then(|v| v.as_bool()),
+        title_contains: args.get("title_contains").and_then(|v| v.as_str().map(String::from)),
+        complexity: args.get("complexity").and_then(|v| v.as_str().map(String::from)),
+        directory: args.get("directory").and_then(|v| v.as_str().map(String::from)),
+        weight_gte: args.get("weight_gte").and_then(|v| v.as_u64().map(|n| n as u32)),
+    }
+}
+
+/// Collect all descendant IDs under a root node (BFS through children).
+fn collect_subtree_ids(graph: &GraphStore, root_id: &str) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    let mut queue = std::collections::VecDeque::new();
+
+    if let Some(root) = graph.resolve(root_id) {
+        queue.push_back(root.id.clone());
+    }
+
+    while let Some(current) = queue.pop_front() {
+        if !ids.insert(current.clone()) {
+            continue;
+        }
+        if let Some(node) = graph.get_node(&current) {
+            for child_id in &node.children {
+                if !ids.contains(child_id) {
+                    queue.push_back(child_id.clone());
+                }
+            }
+        }
+    }
+
+    ids
+}
+
+/// Check if a date string is older than N days from `now`.
+fn is_older_than(date_str: Option<&str>, now: NaiveDate, days: u64) -> bool {
+    let Some(date_str) = date_str else {
+        // No date = treat as infinitely old (matches the filter)
+        return true;
+    };
+
+    // Try parsing as ISO-8601 datetime or date
+    let parsed = if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(date_str) {
+        dt.date_naive()
+    } else if let Ok(d) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+        d
+    } else if let Ok(d) = NaiveDate::parse_from_str(&date_str[..10.min(date_str.len())], "%Y-%m-%d") {
+        d
+    } else {
+        // Can't parse date — skip this filter
+        return true;
+    };
+
+    let age = now.signed_duration_since(parsed).num_days();
+    age >= days as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_set_describe() {
+        let f = FilterSet {
+            project: Some("aops".to_string()),
+            priority_gte: Some(2),
+            ..Default::default()
+        };
+        assert_eq!(f.describe(), "project=aops, priority>=2");
+    }
+
+    #[test]
+    fn test_filter_set_empty() {
+        let f = FilterSet::default();
+        assert!(f.is_empty());
+        assert_eq!(f.describe(), "all tasks");
+    }
+
+    #[test]
+    fn test_is_older_than() {
+        let now = NaiveDate::from_ymd_opt(2026, 3, 9).unwrap();
+        assert!(is_older_than(Some("2026-01-01"), now, 60));
+        assert!(!is_older_than(Some("2026-03-08"), now, 60));
+        assert!(is_older_than(None, now, 60)); // no date = old
+    }
+
+    #[test]
+    fn test_parse_filter_set() {
+        let args = serde_json::json!({
+            "project": "aops",
+            "priority_gte": 2,
+            "tags": ["batch-ops", "spec-ready"],
+            "title_contains": "Write spec"
+        });
+        let f = parse_filter_set(&args);
+        assert_eq!(f.project.as_deref(), Some("aops"));
+        assert_eq!(f.priority_gte, Some(2));
+        assert_eq!(f.tags.as_ref().map(|t| t.len()), Some(2));
+        assert_eq!(f.title_contains.as_deref(), Some("Write spec"));
+    }
+}

--- a/src/batch_ops/mod.rs
+++ b/src/batch_ops/mod.rs
@@ -1,0 +1,210 @@
+//! Batch operations for the task graph.
+//!
+//! Provides [`BatchContext`] for deferred-rebuild batch mutations, and
+//! individual operation modules for update, reparent, archive, and stats.
+
+pub mod filters;
+pub mod reparent;
+pub mod stats;
+pub mod update;
+
+use crate::document_crud;
+use crate::graph_store::GraphStore;
+use crate::pkb;
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Result of a single task operation within a batch.
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskAction {
+    pub id: String,
+    pub title: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_value: Option<String>,
+}
+
+/// Error for a single task within a batch (non-fatal).
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskError {
+    pub id: String,
+    pub error: String,
+}
+
+/// Summary returned by all batch operations.
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchSummary {
+    pub operation: String,
+    pub matched: usize,
+    pub changed: usize,
+    pub skipped: usize,
+    pub tasks: Vec<TaskAction>,
+    pub errors: Vec<TaskError>,
+    pub dry_run: bool,
+}
+
+impl BatchSummary {
+    pub fn new(operation: &str, dry_run: bool) -> Self {
+        Self {
+            operation: operation.to_string(),
+            matched: 0,
+            changed: 0,
+            skipped: 0,
+            tasks: Vec::new(),
+            errors: Vec::new(),
+            dry_run,
+        }
+    }
+
+    /// Format as a human-readable summary table.
+    pub fn display(&self) -> String {
+        let mut out = String::new();
+        if self.dry_run {
+            out.push_str("DRY RUN — no files modified. Pass --execute to apply.\n\n");
+        }
+        out.push_str(&format!(
+            "Batch {}: {} matched, {} changed, {} skipped",
+            self.operation, self.matched, self.changed, self.skipped
+        ));
+        if !self.errors.is_empty() {
+            out.push_str(&format!(", {} errors", self.errors.len()));
+        }
+        out.push('\n');
+
+        if !self.tasks.is_empty() {
+            out.push('\n');
+            // Header
+            out.push_str(&format!(
+                "  {:<24} {:<48} {:<12} {}\n",
+                "ID", "Title", "Action", "Detail"
+            ));
+            out.push_str(&format!("  {}\n", "─".repeat(96)));
+
+            for task in &self.tasks {
+                let title = if task.title.len() > 46 {
+                    let boundary = task.title.floor_char_boundary(43);
+                    format!("{}...", &task.title[..boundary])
+                } else {
+                    task.title.clone()
+                };
+                let detail = task.detail.as_deref().unwrap_or("");
+                out.push_str(&format!(
+                    "  {:<24} {:<48} {:<12} {}\n",
+                    task.id, title, task.action, detail
+                ));
+            }
+        }
+
+        if !self.errors.is_empty() {
+            out.push_str("\nErrors:\n");
+            for err in &self.errors {
+                out.push_str(&format!("  {} — {}\n", err.id, err.error));
+            }
+        }
+
+        out
+    }
+}
+
+/// Context for batch operations with deferred graph rebuild.
+///
+/// Accumulates file modifications and performs a single graph rebuild at the end.
+pub struct BatchContext<'a> {
+    pub graph: &'a GraphStore,
+    pub pkb_root: &'a Path,
+    modified_paths: Vec<PathBuf>,
+}
+
+impl<'a> BatchContext<'a> {
+    pub fn new(graph: &'a GraphStore, pkb_root: &'a Path) -> Self {
+        Self {
+            graph,
+            pkb_root,
+            modified_paths: Vec::new(),
+        }
+    }
+
+    /// Update frontmatter on a single task file. Records the path for later rebuild.
+    pub fn update_task(
+        &mut self,
+        node_id: &str,
+        updates: HashMap<String, serde_json::Value>,
+    ) -> Result<()> {
+        let node = self
+            .graph
+            .get_node(node_id)
+            .context(format!("Node not found: {node_id}"))?;
+
+        let abs_path = self.abs_path(&node.path);
+        if !abs_path.exists() {
+            anyhow::bail!("File not found on disk (index stale?): {}", abs_path.display());
+        }
+
+        document_crud::update_document(&abs_path, updates)?;
+        self.modified_paths.push(abs_path);
+        Ok(())
+    }
+
+    /// Append content to a task file body. Records the path for later rebuild.
+    pub fn append_to_task(
+        &mut self,
+        node_id: &str,
+        content: &str,
+    ) -> Result<()> {
+        let node = self
+            .graph
+            .get_node(node_id)
+            .context(format!("Node not found: {node_id}"))?;
+
+        let abs_path = self.abs_path(&node.path);
+        document_crud::append_to_document(&abs_path, content, None)?;
+        self.modified_paths.push(abs_path);
+        Ok(())
+    }
+
+    /// Resolve a relative path to absolute.
+    fn abs_path(&self, rel: &Path) -> PathBuf {
+        if rel.is_absolute() {
+            rel.to_path_buf()
+        } else {
+            self.pkb_root.join(rel)
+        }
+    }
+
+    /// Paths modified during this batch (for re-indexing).
+    pub fn modified_paths(&self) -> &[PathBuf] {
+        &self.modified_paths
+    }
+
+    /// Re-embed modified documents and rebuild graph.
+    /// Returns the new GraphStore.
+    pub fn rebuild(self) -> GraphStore {
+        GraphStore::build_from_directory(self.pkb_root)
+    }
+
+    /// Re-embed modified documents into vector store, then rebuild graph.
+    /// This is the full finalize path when you have a vector store available.
+    pub fn finalize(
+        self,
+        store: &parking_lot::RwLock<crate::vectordb::VectorStore>,
+        embedder: &crate::embeddings::Embedder,
+        db_path: &Path,
+    ) -> Result<GraphStore> {
+        // Re-embed modified files
+        for path in &self.modified_paths {
+            if let Some(doc) = pkb::parse_file_relative(path, self.pkb_root) {
+                store.write().upsert(&doc, embedder)?;
+            }
+        }
+        // Save vector store
+        store.read().save(db_path)?;
+        // Rebuild graph
+        Ok(GraphStore::build_from_directory(self.pkb_root))
+    }
+}

--- a/src/batch_ops/mod.rs
+++ b/src/batch_ops/mod.rs
@@ -3,7 +3,10 @@
 //! Provides [`BatchContext`] for deferred-rebuild batch mutations, and
 //! individual operation modules for update, reparent, archive, and stats.
 
+pub mod duplicates;
+pub mod epics;
 pub mod filters;
+pub mod reclassify;
 pub mod reparent;
 pub mod stats;
 pub mod update;

--- a/src/batch_ops/reclassify.rs
+++ b/src/batch_ops/reclassify.rs
@@ -1,0 +1,180 @@
+//! `batch_reclassify` — change document type and move files.
+
+use super::{BatchContext, BatchSummary, TaskAction, TaskError};
+use super::filters::FilterSet;
+use crate::graph_store::GraphStore;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Map document type to target subdirectory.
+fn type_to_dir(doc_type: &str) -> &str {
+    match doc_type {
+        "task" | "bug" | "epic" | "feature" | "action" | "learn" => "tasks",
+        "project" | "subproject" => "projects",
+        "goal" => "goals",
+        "memory" | "note" | "insight" | "observation" => "memories",
+        "knowledge" => "notes",
+        _ => "tasks",
+    }
+}
+
+/// Reclassify tasks: change their type and optionally move to correct directory.
+pub fn batch_reclassify(
+    graph: &GraphStore,
+    pkb_root: &Path,
+    filters: &FilterSet,
+    new_type: &str,
+    dry_run: bool,
+) -> BatchSummary {
+    let mut summary = BatchSummary::new("reclassify", dry_run);
+
+    let matched_ids = filters.resolve(graph);
+    summary.matched = matched_ids.len();
+
+    if matched_ids.is_empty() {
+        return summary;
+    }
+
+    let target_dir = type_to_dir(new_type);
+    let mut ctx = BatchContext::new(graph, pkb_root);
+
+    for id in &matched_ids {
+        let node = match graph.get_node(id) {
+            Some(n) => n,
+            None => {
+                summary.errors.push(TaskError {
+                    id: id.clone(),
+                    error: "node not found in graph".to_string(),
+                });
+                continue;
+            }
+        };
+
+        let current_type = node.node_type.as_deref().unwrap_or("unknown");
+
+        // Skip if already the correct type
+        if current_type == new_type {
+            summary.skipped += 1;
+            summary.tasks.push(TaskAction {
+                id: id.clone(),
+                title: node.label.clone(),
+                action: "skipped".to_string(),
+                detail: Some(format!("already type={new_type}")),
+                old_value: None,
+                new_value: None,
+            });
+            continue;
+        }
+
+        let abs_path = if node.path.is_absolute() {
+            node.path.clone()
+        } else {
+            pkb_root.join(&node.path)
+        };
+
+        // Determine if file needs moving
+        let current_dir = abs_path
+            .parent()
+            .and_then(|p| p.file_name())
+            .map(|d| d.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let needs_move = current_dir != target_dir;
+
+        if dry_run {
+            let detail = if needs_move {
+                format!("{current_type}→{new_type}, move to {target_dir}/")
+            } else {
+                format!("{current_type}→{new_type}")
+            };
+            summary.changed += 1;
+            summary.tasks.push(TaskAction {
+                id: id.clone(),
+                title: node.label.clone(),
+                action: "would_reclassify".to_string(),
+                detail: Some(detail),
+                old_value: Some(current_type.to_string()),
+                new_value: Some(new_type.to_string()),
+            });
+            continue;
+        }
+
+        // Update the type field
+        let mut updates = HashMap::new();
+        updates.insert(
+            "type".to_string(),
+            serde_json::Value::String(new_type.to_string()),
+        );
+
+        if let Err(e) = ctx.update_task(id, updates) {
+            summary.errors.push(TaskError {
+                id: id.clone(),
+                error: e.to_string(),
+            });
+            continue;
+        }
+
+        // Move file if needed
+        if needs_move {
+            let target_dir_path = pkb_root.join(target_dir);
+            if !target_dir_path.exists() {
+                if let Err(e) = std::fs::create_dir_all(&target_dir_path) {
+                    summary.errors.push(TaskError {
+                        id: id.clone(),
+                        error: format!("failed to create dir {target_dir}: {e}"),
+                    });
+                    continue;
+                }
+            }
+
+            let filename = abs_path
+                .file_name()
+                .map(|f| f.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let new_path = target_dir_path.join(&filename);
+
+            match std::fs::rename(&abs_path, &new_path) {
+                Ok(()) => {
+                    summary.changed += 1;
+                    summary.tasks.push(TaskAction {
+                        id: id.clone(),
+                        title: node.label.clone(),
+                        action: "reclassified".to_string(),
+                        detail: Some(format!(
+                            "{current_type}→{new_type}, moved to {target_dir}/{filename}"
+                        )),
+                        old_value: Some(current_type.to_string()),
+                        new_value: Some(new_type.to_string()),
+                    });
+                }
+                Err(e) => {
+                    // Type was updated but move failed
+                    summary.changed += 1;
+                    summary.errors.push(TaskError {
+                        id: id.clone(),
+                        error: format!("type updated but file move failed: {e}"),
+                    });
+                    summary.tasks.push(TaskAction {
+                        id: id.clone(),
+                        title: node.label.clone(),
+                        action: "reclassified".to_string(),
+                        detail: Some(format!("{current_type}→{new_type} (move failed)")),
+                        old_value: Some(current_type.to_string()),
+                        new_value: Some(new_type.to_string()),
+                    });
+                }
+            }
+        } else {
+            summary.changed += 1;
+            summary.tasks.push(TaskAction {
+                id: id.clone(),
+                title: node.label.clone(),
+                action: "reclassified".to_string(),
+                detail: Some(format!("{current_type}→{new_type}")),
+                old_value: Some(current_type.to_string()),
+                new_value: Some(new_type.to_string()),
+            });
+        }
+    }
+
+    summary
+}

--- a/src/batch_ops/reparent.rs
+++ b/src/batch_ops/reparent.rs
@@ -1,0 +1,146 @@
+//! `batch_reparent` — move multiple tasks to a new parent.
+
+use super::{BatchContext, BatchSummary, TaskAction, TaskError};
+use super::filters::FilterSet;
+use crate::graph_store::GraphStore;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Execute a batch reparent operation.
+///
+/// Moves all tasks matching `filters` under `new_parent_id`.
+/// If `update_project` is true (default), also propagates the parent's project field.
+pub fn batch_reparent(
+    graph: &GraphStore,
+    pkb_root: &Path,
+    filters: &FilterSet,
+    new_parent_id: &str,
+    update_project: bool,
+    dry_run: bool,
+) -> BatchSummary {
+    let mut summary = BatchSummary::new("reparent", dry_run);
+
+    // Validate new parent exists
+    let new_parent = match graph.resolve(new_parent_id) {
+        Some(n) => n,
+        None => {
+            summary.errors.push(TaskError {
+                id: new_parent_id.to_string(),
+                error: "new parent not found in graph".to_string(),
+            });
+            return summary;
+        }
+    };
+    let canonical_parent_id = new_parent.id.clone();
+    let parent_project = new_parent.project.clone();
+
+    let matched_ids = filters.resolve(graph);
+    summary.matched = matched_ids.len();
+
+    if matched_ids.is_empty() {
+        return summary;
+    }
+
+    let mut ctx = BatchContext::new(graph, pkb_root);
+
+    for id in &matched_ids {
+        // Don't reparent a node under itself
+        if id == &canonical_parent_id {
+            summary.skipped += 1;
+            summary.tasks.push(TaskAction {
+                id: id.clone(),
+                title: graph.get_node(id).map(|n| n.label.clone()).unwrap_or_default(),
+                action: "skipped".to_string(),
+                detail: Some("cannot reparent under self".to_string()),
+                old_value: None,
+                new_value: None,
+            });
+            continue;
+        }
+
+        let node = match graph.get_node(id) {
+            Some(n) => n,
+            None => {
+                summary.errors.push(TaskError {
+                    id: id.clone(),
+                    error: "node not found in graph".to_string(),
+                });
+                continue;
+            }
+        };
+
+        // Skip if already under this parent (idempotent)
+        if node.parent.as_deref() == Some(&canonical_parent_id) {
+            let needs_project_update = update_project
+                && parent_project.is_some()
+                && node.project != parent_project;
+
+            if !needs_project_update {
+                summary.skipped += 1;
+                summary.tasks.push(TaskAction {
+                    id: id.clone(),
+                    title: node.label.clone(),
+                    action: "skipped".to_string(),
+                    detail: Some(format!("already under {canonical_parent_id}")),
+                    old_value: None,
+                    new_value: None,
+                });
+                continue;
+            }
+        }
+
+        let old_parent = node.parent.clone();
+
+        if dry_run {
+            summary.changed += 1;
+            summary.tasks.push(TaskAction {
+                id: id.clone(),
+                title: node.label.clone(),
+                action: "would_reparent".to_string(),
+                detail: Some(format!("→ {canonical_parent_id}")),
+                old_value: old_parent,
+                new_value: Some(canonical_parent_id.clone()),
+            });
+            continue;
+        }
+
+        // Build updates
+        let mut updates = HashMap::new();
+        updates.insert(
+            "parent".to_string(),
+            serde_json::Value::String(canonical_parent_id.clone()),
+        );
+
+        // Cascade project if requested
+        if update_project {
+            if let Some(ref project) = parent_project {
+                updates.insert(
+                    "project".to_string(),
+                    serde_json::Value::String(project.clone()),
+                );
+            }
+        }
+
+        match ctx.update_task(id, updates) {
+            Ok(()) => {
+                summary.changed += 1;
+                summary.tasks.push(TaskAction {
+                    id: id.clone(),
+                    title: node.label.clone(),
+                    action: "reparented".to_string(),
+                    detail: Some(format!("→ {canonical_parent_id}")),
+                    old_value: old_parent,
+                    new_value: Some(canonical_parent_id.clone()),
+                });
+            }
+            Err(e) => {
+                summary.errors.push(TaskError {
+                    id: id.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    summary
+}

--- a/src/batch_ops/stats.rs
+++ b/src/batch_ops/stats.rs
@@ -1,0 +1,231 @@
+//! `graph_stats` — read-only graph health report.
+
+use crate::graph::is_completed;
+use crate::graph_store::{GraphStore, ACTIONABLE_TYPES};
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Graph health statistics.
+#[derive(Debug, Serialize)]
+pub struct GraphStats {
+    /// Count by status
+    pub status_counts: HashMap<String, usize>,
+    /// Total actionable tasks
+    pub total_tasks: usize,
+    /// Tasks with no parent and no project
+    pub orphan_count: usize,
+    /// Deepest nesting level
+    pub max_depth: usize,
+    /// Count of leaf tasks directly under a project (no epic grouping)
+    pub flat_tasks: usize,
+    /// Tasks not modified in >60 days
+    pub stale_count: usize,
+    /// Count per priority level
+    pub priority_distribution: HashMap<String, usize>,
+    /// Count per document type
+    pub type_distribution: HashMap<String, usize>,
+    /// Epics with no children
+    pub disconnected_epics: usize,
+    /// Projects not linked to any goal
+    pub projects_without_goals: usize,
+}
+
+impl GraphStats {
+    /// Format as human-readable report.
+    pub fn display(&self) -> String {
+        let mut out = String::new();
+        out.push_str("Graph Health Report\n");
+        out.push_str(&format!("{}\n\n", "═".repeat(40)));
+
+        out.push_str(&format!("Total actionable tasks: {}\n\n", self.total_tasks));
+
+        // Status breakdown
+        out.push_str("Status breakdown:\n");
+        let mut statuses: Vec<_> = self.status_counts.iter().collect();
+        statuses.sort_by(|a, b| b.1.cmp(a.1));
+        for (status, count) in &statuses {
+            out.push_str(&format!("  {:<16} {}\n", status, count));
+        }
+
+        // Priority breakdown
+        out.push_str("\nPriority breakdown:\n");
+        let mut priorities: Vec<_> = self.priority_distribution.iter().collect();
+        priorities.sort_by_key(|(k, _)| k.parse::<i32>().unwrap_or(99));
+        for (priority, count) in &priorities {
+            let label = match priority.as_str() {
+                "0" => "P0 (critical)",
+                "1" => "P1 (high)",
+                "2" => "P2 (medium)",
+                "3" => "P3 (low)",
+                "4" => "P4 (someday)",
+                _ => priority,
+            };
+            out.push_str(&format!("  {:<20} {}\n", label, count));
+        }
+
+        // Type breakdown
+        out.push_str("\nType breakdown:\n");
+        let mut types: Vec<_> = self.type_distribution.iter().collect();
+        types.sort_by(|a, b| b.1.cmp(a.1));
+        for (doc_type, count) in &types {
+            out.push_str(&format!("  {:<16} {}\n", doc_type, count));
+        }
+
+        // Health indicators
+        out.push_str("\nHealth indicators:\n");
+        out.push_str(&format!("  Orphans:              {}\n", self.orphan_count));
+        out.push_str(&format!("  Flat tasks:           {}\n", self.flat_tasks));
+        out.push_str(&format!(
+            "  Stale (>60d):         {}\n",
+            self.stale_count
+        ));
+        out.push_str(&format!("  Max depth:            {}\n", self.max_depth));
+        out.push_str(&format!(
+            "  Empty epics:          {}\n",
+            self.disconnected_epics
+        ));
+        out.push_str(&format!(
+            "  Projects w/o goals:   {}\n",
+            self.projects_without_goals
+        ));
+
+        out
+    }
+}
+
+/// Compute graph health statistics.
+pub fn graph_stats(graph: &GraphStore, project: Option<&str>) -> GraphStats {
+    let now = chrono::Utc::now().date_naive();
+    let stale_threshold = 60i64;
+
+    let mut status_counts: HashMap<String, usize> = HashMap::new();
+    let mut priority_distribution: HashMap<String, usize> = HashMap::new();
+    let mut type_distribution: HashMap<String, usize> = HashMap::new();
+    let mut total_tasks = 0usize;
+    let mut orphan_count = 0usize;
+    let mut max_depth = 0usize;
+    let mut flat_tasks = 0usize;
+    let mut stale_count = 0usize;
+    let mut disconnected_epics = 0usize;
+    let mut projects_without_goals = 0usize;
+
+    for node in graph.nodes() {
+        // Project filter
+        if let Some(project) = project {
+            if node.project.as_deref() != Some(project) {
+                continue;
+            }
+        }
+
+        let node_type = node.node_type.as_deref().unwrap_or("unknown");
+
+        // Only count actionable types
+        if !ACTIONABLE_TYPES.contains(&node_type) {
+            // Still count type distribution
+            *type_distribution
+                .entry(node_type.to_string())
+                .or_insert(0) += 1;
+            continue;
+        }
+
+        total_tasks += 1;
+
+        // Status
+        let status = node.status.as_deref().unwrap_or("unknown");
+        *status_counts.entry(status.to_string()).or_insert(0) += 1;
+
+        // Skip completed for most metrics
+        if is_completed(node.status.as_deref()) {
+            *type_distribution
+                .entry(node_type.to_string())
+                .or_insert(0) += 1;
+            continue;
+        }
+
+        // Priority
+        let priority = node.priority.unwrap_or(2);
+        *priority_distribution
+            .entry(priority.to_string())
+            .or_insert(0) += 1;
+
+        // Type
+        *type_distribution
+            .entry(node_type.to_string())
+            .or_insert(0) += 1;
+
+        // Orphan: no parent AND no project
+        if node.parent.is_none() && node.project.is_none() {
+            orphan_count += 1;
+        }
+
+        // Depth
+        let depth = node.depth as usize;
+        if depth > max_depth {
+            max_depth = depth;
+        }
+
+        // Flat tasks: leaf tasks whose parent is a project (not an epic)
+        if node.leaf && node.children.is_empty() {
+            if let Some(ref parent_id) = node.parent {
+                if let Some(parent) = graph.get_node(parent_id) {
+                    if parent.node_type.as_deref() == Some("project") {
+                        flat_tasks += 1;
+                    }
+                }
+            }
+        }
+
+        // Stale check
+        let date_str = node.modified.as_deref().or(node.created.as_deref());
+        if let Some(ds) = date_str {
+            if let Some(age_days) = parse_age_days(ds, now) {
+                if age_days > stale_threshold {
+                    stale_count += 1;
+                }
+            }
+        }
+
+        // Disconnected epics (epics with no children)
+        if node_type == "epic" && node.children.is_empty() {
+            disconnected_epics += 1;
+        }
+
+        // Projects without goals (projects with no parent, or parent isn't a goal)
+        if node_type == "project" {
+            let has_goal_parent = node.parent.as_ref().and_then(|pid| {
+                graph.get_node(pid)
+            }).map(|p| p.node_type.as_deref() == Some("goal")).unwrap_or(false);
+            if !has_goal_parent {
+                projects_without_goals += 1;
+            }
+        }
+    }
+
+    GraphStats {
+        status_counts,
+        total_tasks,
+        orphan_count,
+        max_depth,
+        flat_tasks,
+        stale_count,
+        priority_distribution,
+        type_distribution,
+        disconnected_epics,
+        projects_without_goals,
+    }
+}
+
+/// Parse age in days from a date string.
+fn parse_age_days(date_str: &str, now: chrono::NaiveDate) -> Option<i64> {
+    let parsed = if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(date_str) {
+        dt.date_naive()
+    } else if let Ok(d) = chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+        d
+    } else if date_str.len() >= 10 {
+        chrono::NaiveDate::parse_from_str(&date_str[..10], "%Y-%m-%d").ok()?
+    } else {
+        return None;
+    };
+
+    Some(now.signed_duration_since(parsed).num_days())
+}

--- a/src/batch_ops/update.rs
+++ b/src/batch_ops/update.rs
@@ -1,0 +1,368 @@
+//! `batch_update` — update frontmatter fields across multiple tasks.
+//!
+//! Covers the general case: status changes, priority adjustments, tag
+//! modifications, field removal, and supersedes marking.
+
+use super::{BatchContext, BatchSummary, TaskAction, TaskError};
+use super::filters::FilterSet;
+use crate::graph_store::GraphStore;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Special update keys that get transformed (not set directly).
+const SPECIAL_KEYS: &[&str] = &[
+    "_add_tags",
+    "_remove_tags",
+    "_add_depends_on",
+    "_remove_depends_on",
+];
+
+/// Execute a batch update operation.
+///
+/// Applies `updates` to all tasks matching `filters`. Supports special
+/// keys like `_add_tags` and `_remove_tags` for array manipulation.
+pub fn batch_update(
+    graph: &GraphStore,
+    pkb_root: &Path,
+    filters: &FilterSet,
+    updates: &serde_json::Value,
+    dry_run: bool,
+) -> BatchSummary {
+    let mut summary = BatchSummary::new("update", dry_run);
+
+    let matched_ids = filters.resolve(graph);
+    summary.matched = matched_ids.len();
+
+    if matched_ids.is_empty() {
+        return summary;
+    }
+
+    let updates_map = match updates.as_object() {
+        Some(m) => m,
+        None => {
+            summary.errors.push(TaskError {
+                id: "".to_string(),
+                error: "updates must be a JSON object".to_string(),
+            });
+            return summary;
+        }
+    };
+
+    let mut ctx = BatchContext::new(graph, pkb_root);
+
+    for id in &matched_ids {
+        let node = match graph.get_node(id) {
+            Some(n) => n,
+            None => {
+                summary.errors.push(TaskError {
+                    id: id.clone(),
+                    error: "node not found in graph".to_string(),
+                });
+                continue;
+            }
+        };
+
+        // Build the effective updates for this node
+        let effective = build_effective_updates(updates_map, node);
+        if effective.is_empty() {
+            summary.skipped += 1;
+            summary.tasks.push(TaskAction {
+                id: id.clone(),
+                title: node.label.clone(),
+                action: "skipped".to_string(),
+                detail: Some("no changes needed".to_string()),
+                old_value: None,
+                new_value: None,
+            });
+            continue;
+        }
+
+        let detail = describe_updates(&effective);
+
+        if dry_run {
+            summary.changed += 1;
+            summary.tasks.push(TaskAction {
+                id: id.clone(),
+                title: node.label.clone(),
+                action: "would_update".to_string(),
+                detail: Some(detail),
+                old_value: None,
+                new_value: None,
+            });
+            continue;
+        }
+
+        // Apply updates
+        match ctx.update_task(id, effective) {
+            Ok(()) => {
+                summary.changed += 1;
+                summary.tasks.push(TaskAction {
+                    id: id.clone(),
+                    title: node.label.clone(),
+                    action: "updated".to_string(),
+                    detail: Some(detail),
+                    old_value: None,
+                    new_value: None,
+                });
+            }
+            Err(e) => {
+                summary.errors.push(TaskError {
+                    id: id.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    summary
+}
+
+/// Execute a batch archive (convenience wrapper with dry-run-by-default).
+pub fn batch_archive(
+    graph: &GraphStore,
+    pkb_root: &Path,
+    filters: &FilterSet,
+    reason: Option<&str>,
+    dry_run: bool,
+) -> BatchSummary {
+    let mut summary = BatchSummary::new("archive", dry_run);
+
+    let matched_ids = filters.resolve(graph);
+    summary.matched = matched_ids.len();
+
+    if matched_ids.is_empty() {
+        return summary;
+    }
+
+    let mut ctx = BatchContext::new(graph, pkb_root);
+
+    for id in &matched_ids {
+        let node = match graph.get_node(id) {
+            Some(n) => n,
+            None => {
+                summary.errors.push(TaskError {
+                    id: id.clone(),
+                    error: "node not found in graph".to_string(),
+                });
+                continue;
+            }
+        };
+
+        // Skip already archived
+        if node.status.as_deref() == Some("done") || node.status.as_deref() == Some("cancelled") {
+            summary.skipped += 1;
+            summary.tasks.push(TaskAction {
+                id: id.clone(),
+                title: node.label.clone(),
+                action: "skipped".to_string(),
+                detail: Some(format!("already {}", node.status.as_deref().unwrap_or("done"))),
+                old_value: None,
+                new_value: None,
+            });
+            continue;
+        }
+
+        // Warn about in_progress tasks
+        let mut warnings = Vec::new();
+        if node.status.as_deref() == Some("in_progress") {
+            warnings.push("was in_progress");
+        }
+        if !node.children.is_empty() {
+            let active_children: Vec<_> = node.children.iter().filter(|cid| {
+                graph.get_node(cid)
+                    .map(|c| !crate::graph::is_completed(c.status.as_deref()))
+                    .unwrap_or(false)
+            }).collect();
+            if !active_children.is_empty() {
+                warnings.push("has active children");
+            }
+        }
+
+        let detail = if warnings.is_empty() {
+            None
+        } else {
+            Some(format!("⚠ {}", warnings.join(", ")))
+        };
+
+        if dry_run {
+            summary.changed += 1;
+            summary.tasks.push(TaskAction {
+                id: id.clone(),
+                title: node.label.clone(),
+                action: "would_archive".to_string(),
+                detail,
+                old_value: node.status.clone(),
+                new_value: Some("done".to_string()),
+            });
+            continue;
+        }
+
+        // Set status to done
+        let mut updates = HashMap::new();
+        updates.insert(
+            "status".to_string(),
+            serde_json::Value::String("done".to_string()),
+        );
+
+        match ctx.update_task(id, updates) {
+            Ok(()) => {
+                // Append archive reason if provided
+                if let Some(reason) = reason {
+                    let note = format!("<!-- archived {}: {} -->",
+                        chrono::Utc::now().format("%Y-%m-%d"), reason);
+                    let _ = ctx.append_to_task(id, &note);
+                }
+                summary.changed += 1;
+                summary.tasks.push(TaskAction {
+                    id: id.clone(),
+                    title: node.label.clone(),
+                    action: "archived".to_string(),
+                    detail,
+                    old_value: node.status.clone(),
+                    new_value: Some("done".to_string()),
+                });
+            }
+            Err(e) => {
+                summary.errors.push(TaskError {
+                    id: id.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    summary
+}
+
+/// Build the effective update HashMap for a node, handling special keys.
+fn build_effective_updates(
+    updates_map: &serde_json::Map<String, serde_json::Value>,
+    node: &crate::graph::GraphNode,
+) -> HashMap<String, serde_json::Value> {
+    let mut effective = HashMap::new();
+
+    for (key, value) in updates_map {
+        if SPECIAL_KEYS.contains(&key.as_str()) {
+            continue; // Handle below
+        }
+
+        // Check if this would be a no-op
+        let is_noop = match key.as_str() {
+            "status" => node.status.as_deref() == value.as_str(),
+            "priority" => node.priority == value.as_i64().map(|v| v as i32),
+            "project" => node.project.as_deref() == value.as_str(),
+            "assignee" => node.assignee.as_deref() == value.as_str(),
+            "complexity" => node.complexity.as_deref() == value.as_str(),
+            "parent" => node.parent.as_deref() == value.as_str(),
+            _ => false,
+        };
+
+        if !is_noop {
+            effective.insert(key.clone(), value.clone());
+        }
+    }
+
+    // Handle _add_tags
+    if let Some(add_tags) = updates_map.get("_add_tags").and_then(|v| v.as_array()) {
+        let new_tags: Vec<String> = add_tags
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .filter(|t| !node.tags.contains(t))
+            .collect();
+        if !new_tags.is_empty() {
+            let mut all_tags = node.tags.clone();
+            all_tags.extend(new_tags);
+            effective.insert(
+                "tags".to_string(),
+                serde_json::Value::Array(all_tags.into_iter().map(serde_json::Value::String).collect()),
+            );
+        }
+    }
+
+    // Handle _remove_tags
+    if let Some(remove_tags) = updates_map.get("_remove_tags").and_then(|v| v.as_array()) {
+        let remove_set: std::collections::HashSet<&str> = remove_tags
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        if node.tags.iter().any(|t| remove_set.contains(t.as_str())) {
+            let remaining: Vec<String> = node
+                .tags
+                .iter()
+                .filter(|t| !remove_set.contains(t.as_str()))
+                .cloned()
+                .collect();
+            effective.insert(
+                "tags".to_string(),
+                serde_json::Value::Array(remaining.into_iter().map(serde_json::Value::String).collect()),
+            );
+        }
+    }
+
+    // Handle _add_depends_on
+    if let Some(add_deps) = updates_map.get("_add_depends_on").and_then(|v| v.as_array()) {
+        let new_deps: Vec<String> = add_deps
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .filter(|d| !node.depends_on.contains(d))
+            .collect();
+        if !new_deps.is_empty() {
+            let mut all_deps = node.depends_on.clone();
+            all_deps.extend(new_deps);
+            effective.insert(
+                "depends_on".to_string(),
+                serde_json::Value::Array(all_deps.into_iter().map(serde_json::Value::String).collect()),
+            );
+        }
+    }
+
+    // Handle _remove_depends_on
+    if let Some(remove_deps) = updates_map.get("_remove_depends_on").and_then(|v| v.as_array()) {
+        let remove_set: std::collections::HashSet<&str> = remove_deps
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        if node.depends_on.iter().any(|d| remove_set.contains(d.as_str())) {
+            let remaining: Vec<String> = node
+                .depends_on
+                .iter()
+                .filter(|d| !remove_set.contains(d.as_str()))
+                .cloned()
+                .collect();
+            effective.insert(
+                "depends_on".to_string(),
+                serde_json::Value::Array(remaining.into_iter().map(serde_json::Value::String).collect()),
+            );
+        }
+    }
+
+    // Handle superseded_by (sets status to done + superseded_by field)
+    if let Some(superseded_by) = updates_map.get("superseded_by") {
+        effective.insert("superseded_by".to_string(), superseded_by.clone());
+        if !effective.contains_key("status") {
+            effective.insert(
+                "status".to_string(),
+                serde_json::Value::String("done".to_string()),
+            );
+        }
+    }
+
+    effective
+}
+
+/// Describe updates in human-readable form.
+fn describe_updates(updates: &HashMap<String, serde_json::Value>) -> String {
+    updates
+        .iter()
+        .map(|(k, v)| {
+            if v.is_null() {
+                format!("unset {k}")
+            } else if let Some(s) = v.as_str() {
+                format!("{k}={s}")
+            } else {
+                format!("{k}={v}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -435,6 +435,158 @@ enum Commands {
         #[arg(short = 'k', long, default_value_t = 10)]
         top_k: usize,
     },
+
+    /// Batch operations on the task graph
+    #[command(subcommand)]
+    Batch(BatchCommands),
+
+    /// Show graph health statistics
+    GraphStats {
+        /// Filter by project
+        #[arg(short, long)]
+        project: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum BatchCommands {
+    /// Update frontmatter fields across multiple tasks
+    Update {
+        /// Set a field: key=value (repeatable)
+        #[arg(long = "set", value_name = "KEY=VALUE")]
+        set_fields: Option<Vec<String>>,
+
+        /// Remove a field (repeatable)
+        #[arg(long = "unset", value_name = "KEY")]
+        unset_fields: Option<Vec<String>>,
+
+        /// Add a tag (repeatable)
+        #[arg(long = "add-tag", value_name = "TAG")]
+        add_tags: Option<Vec<String>>,
+
+        /// Remove a tag (repeatable)
+        #[arg(long = "remove-tag", value_name = "TAG")]
+        remove_tags: Option<Vec<String>>,
+
+        /// Dry run — preview changes without writing
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+
+        #[command(flatten)]
+        filters: BatchFilterArgs,
+    },
+
+    /// Move multiple tasks to a new parent
+    Reparent {
+        /// ID of new parent (flexible resolution)
+        #[arg(long)]
+        new_parent: String,
+
+        /// Don't cascade parent's project field
+        #[arg(long)]
+        no_cascade: bool,
+
+        /// Dry run — preview changes without writing
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+
+        #[command(flatten)]
+        filters: BatchFilterArgs,
+    },
+
+    /// Archive tasks (set status to done). Dry-run by default.
+    Archive {
+        /// Actually execute (archive is dry-run by default)
+        #[arg(long)]
+        execute: bool,
+
+        /// Archive reason (appended to task body)
+        #[arg(long)]
+        reason: Option<String>,
+
+        /// Skip confirmation prompt
+        #[arg(long)]
+        yes: bool,
+
+        #[command(flatten)]
+        filters: BatchFilterArgs,
+    },
+}
+
+/// Shared filter arguments for batch commands.
+#[derive(clap::Args, Debug, Clone)]
+struct BatchFilterArgs {
+    /// Explicit task IDs (comma-separated)
+    #[arg(long, value_delimiter = ',')]
+    ids: Option<Vec<String>>,
+
+    /// Filter by project
+    #[arg(long)]
+    project: Option<String>,
+
+    /// Filter by parent (direct children)
+    #[arg(long)]
+    parent: Option<String>,
+
+    /// Filter by subtree (all descendants)
+    #[arg(long)]
+    subtree: Option<String>,
+
+    /// Filter by status
+    #[arg(long)]
+    status: Option<String>,
+
+    /// Filter by exact priority
+    #[arg(long)]
+    priority: Option<i32>,
+
+    /// Filter by minimum priority (>=)
+    #[arg(long)]
+    priority_gte: Option<i32>,
+
+    /// Filter by tags (must have ALL, comma-separated)
+    #[arg(long, value_delimiter = ',')]
+    tags: Option<Vec<String>>,
+
+    /// Filter by document type
+    #[arg(long = "type")]
+    doc_type: Option<String>,
+
+    /// Filter by age: older than N days (format: "90d")
+    #[arg(long)]
+    older_than: Option<String>,
+
+    /// Filter by staleness: not modified in N days (format: "60d")
+    #[arg(long)]
+    stale: Option<String>,
+
+    /// Filter orphan tasks (no parent, no project)
+    #[arg(long)]
+    orphan: bool,
+
+    /// Filter by title substring (case-insensitive)
+    #[arg(long)]
+    title_contains: Option<String>,
+
+    /// Filter by complexity
+    #[arg(long)]
+    complexity: Option<String>,
+
+    /// Filter by directory path
+    #[arg(long)]
+    directory: Option<String>,
+
+    /// Filter by minimum downstream weight
+    #[arg(long)]
+    weight_gte: Option<u32>,
 }
 
 fn default_pkb_root() -> String {
@@ -2312,6 +2464,171 @@ fn main() -> Result<()> {
 
         Commands::Tui => {
             tui::run(&pkb_root, &db_path)?;
+        }
+
+        Commands::Batch(batch_cmd) => {
+            let graph = load_graph(&pkb_root, &db_path);
+            handle_batch_command(batch_cmd, &graph, &pkb_root)?;
+        }
+
+        Commands::GraphStats { project } => {
+            let graph = load_graph(&pkb_root, &db_path);
+            let stats = mem::batch_ops::stats::graph_stats(&graph, project.as_deref());
+            print!("{}", stats.display());
+        }
+    }
+
+    Ok(())
+}
+
+/// Convert CLI filter args to a FilterSet.
+fn to_filter_set(args: &BatchFilterArgs) -> mem::batch_ops::filters::FilterSet {
+    mem::batch_ops::filters::FilterSet {
+        ids: args.ids.clone(),
+        project: args.project.clone(),
+        parent: args.parent.clone(),
+        subtree: args.subtree.clone(),
+        status: args.status.clone(),
+        priority: args.priority,
+        priority_gte: args.priority_gte,
+        tags: args.tags.clone(),
+        doc_type: args.doc_type.clone(),
+        older_than_days: args.older_than.as_ref().and_then(parse_duration_days),
+        stale_days: args.stale.as_ref().and_then(parse_duration_days),
+        orphan: if args.orphan { Some(true) } else { None },
+        title_contains: args.title_contains.clone(),
+        complexity: args.complexity.clone(),
+        directory: args.directory.clone(),
+        weight_gte: args.weight_gte,
+    }
+}
+
+/// Parse duration like "90d" into days.
+fn parse_duration_days(s: &String) -> Option<u64> {
+    let s = s.trim();
+    if s.ends_with('d') {
+        s[..s.len() - 1].parse().ok()
+    } else {
+        s.parse().ok()
+    }
+}
+
+/// Handle batch subcommands.
+fn handle_batch_command(
+    cmd: BatchCommands,
+    graph: &graph_store::GraphStore,
+    pkb_root: &std::path::Path,
+) -> Result<()> {
+    match cmd {
+        BatchCommands::Update {
+            set_fields,
+            unset_fields,
+            add_tags,
+            remove_tags,
+            dry_run,
+            yes: _,
+            filters,
+        } => {
+            let filter_set = to_filter_set(&filters);
+            if filter_set.is_empty() {
+                eprintln!("Error: at least one filter is required for batch update");
+                std::process::exit(1);
+            }
+
+            // Build updates JSON
+            let mut updates = serde_json::Map::new();
+            if let Some(set_fields) = set_fields {
+                for field in set_fields {
+                    if let Some((key, value)) = field.split_once('=') {
+                        // Try to parse as number or bool, fall back to string
+                        let json_val = if let Ok(n) = value.parse::<i64>() {
+                            serde_json::Value::Number(n.into())
+                        } else if value == "true" {
+                            serde_json::Value::Bool(true)
+                        } else if value == "false" {
+                            serde_json::Value::Bool(false)
+                        } else {
+                            serde_json::Value::String(value.to_string())
+                        };
+                        updates.insert(key.to_string(), json_val);
+                    } else {
+                        eprintln!("Warning: ignoring malformed --set: {field}");
+                    }
+                }
+            }
+            if let Some(unset_fields) = unset_fields {
+                for field in unset_fields {
+                    updates.insert(field, serde_json::Value::Null);
+                }
+            }
+            if let Some(tags) = add_tags {
+                updates.insert(
+                    "_add_tags".to_string(),
+                    serde_json::Value::Array(tags.into_iter().map(serde_json::Value::String).collect()),
+                );
+            }
+            if let Some(tags) = remove_tags {
+                updates.insert(
+                    "_remove_tags".to_string(),
+                    serde_json::Value::Array(tags.into_iter().map(serde_json::Value::String).collect()),
+                );
+            }
+
+            if updates.is_empty() {
+                eprintln!("Error: no updates specified (use --set, --unset, --add-tag, or --remove-tag)");
+                std::process::exit(1);
+            }
+
+            let updates_val = serde_json::Value::Object(updates);
+            let summary = mem::batch_ops::update::batch_update(graph, pkb_root, &filter_set, &updates_val, dry_run);
+            print!("{}", summary.display());
+        }
+
+        BatchCommands::Reparent {
+            new_parent,
+            no_cascade,
+            dry_run,
+            yes: _,
+            filters,
+        } => {
+            let filter_set = to_filter_set(&filters);
+            if filter_set.is_empty() {
+                eprintln!("Error: at least one filter is required for batch reparent");
+                std::process::exit(1);
+            }
+
+            let summary = mem::batch_ops::reparent::batch_reparent(
+                graph,
+                pkb_root,
+                &filter_set,
+                &new_parent,
+                !no_cascade,
+                dry_run,
+            );
+            print!("{}", summary.display());
+        }
+
+        BatchCommands::Archive {
+            execute,
+            reason,
+            yes: _,
+            filters,
+        } => {
+            let filter_set = to_filter_set(&filters);
+            if filter_set.is_empty() {
+                eprintln!("Error: at least one filter is required for batch archive");
+                std::process::exit(1);
+            }
+
+            let dry_run = !execute;
+            let summary = mem::batch_ops::update::batch_archive(
+                graph,
+                pkb_root,
+                &filter_set,
+                reason.as_deref(),
+                dry_run,
+            );
+            print!("{}", summary.display());
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -446,6 +446,29 @@ enum Commands {
         #[arg(short, long)]
         project: Option<String>,
     },
+
+    /// Find potential duplicate tasks
+    Duplicates {
+        /// Filter by project
+        #[arg(short, long)]
+        project: Option<String>,
+
+        /// Detection mode: title, semantic, or both
+        #[arg(long, default_value = "title")]
+        mode: String,
+
+        /// Title similarity threshold (0.0-1.0, default: 0.7)
+        #[arg(long, default_value_t = 0.7)]
+        title_threshold: f64,
+
+        /// Semantic similarity threshold (0.0-1.0, default: 0.85)
+        #[arg(long, default_value_t = 0.85)]
+        semantic_threshold: f64,
+
+        /// Maximum clusters to show
+        #[arg(short = 'n', long, default_value_t = 20)]
+        limit: usize,
+    },
 }
 
 #[derive(Subcommand)]
@@ -515,6 +538,54 @@ enum BatchCommands {
         /// Skip confirmation prompt
         #[arg(long)]
         yes: bool,
+
+        #[command(flatten)]
+        filters: BatchFilterArgs,
+    },
+
+    /// Merge duplicate tasks into a canonical task
+    Merge {
+        /// ID of the canonical task to keep
+        #[arg(long)]
+        canonical: String,
+
+        /// IDs of tasks to merge into canonical (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        merge: Vec<String>,
+
+        /// Dry run — preview changes without writing
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Create epic containers and reparent tasks under them
+    CreateEpics {
+        /// Load epic definitions from YAML file
+        #[arg(long)]
+        from: String,
+
+        /// Parent for all new epics
+        #[arg(long)]
+        parent: Option<String>,
+
+        /// Project for all new epics
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Dry run — preview changes without writing
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Change document type and move to correct directory
+    Reclassify {
+        /// New document type (task, memory, note, knowledge, project, epic, goal)
+        #[arg(long)]
+        new_type: String,
+
+        /// Dry run — preview changes without writing
+        #[arg(long)]
+        dry_run: bool,
 
         #[command(flatten)]
         filters: BatchFilterArgs,
@@ -647,7 +718,10 @@ fn main() -> Result<()> {
     // Some commands need the store but not the embedder
     let needs_store_only = matches!(
         cli.command,
-        Commands::Tags { .. } | Commands::Memories { .. } | Commands::Forget { .. }
+        Commands::Tags { .. }
+            | Commands::Memories { .. }
+            | Commands::Forget { .. }
+            | Commands::Duplicates { .. }
     );
 
     let (embedder, store) = if needs_embedder {
@@ -2476,6 +2550,62 @@ fn main() -> Result<()> {
             let stats = mem::batch_ops::stats::graph_stats(&graph, project.as_deref());
             print!("{}", stats.display());
         }
+
+        Commands::Duplicates {
+            project,
+            mode,
+            title_threshold,
+            semantic_threshold,
+            limit,
+        } => {
+            let graph = load_graph(&pkb_root, &db_path);
+            let store = load_store(&db_path, embeddings::EMBEDDING_DIM)?;
+
+            let mut filters = mem::batch_ops::filters::FilterSet::default();
+            filters.project = project;
+
+            let dup_mode = mem::batch_ops::duplicates::DuplicateMode::from_str(&mode);
+            let report = mem::batch_ops::duplicates::find_duplicates(
+                &graph,
+                &store.read(),
+                &filters,
+                dup_mode,
+                title_threshold,
+                semantic_threshold,
+            );
+
+            if report.clusters.is_empty() {
+                println!("No duplicates found.");
+            } else {
+                println!(
+                    "Found {} duplicate clusters ({} total duplicates)\n",
+                    report.total_clusters, report.total_duplicates
+                );
+                for (i, cluster) in report.clusters.iter().take(limit).enumerate() {
+                    println!(
+                        "Cluster {} (confidence: {:.2}, title: {:.2}, semantic: {:.2}):",
+                        i + 1,
+                        cluster.confidence,
+                        cluster.similarity_scores.title,
+                        cluster.similarity_scores.semantic,
+                    );
+                    for task in &cluster.tasks {
+                        let marker = if task.id == cluster.canonical {
+                            "★"
+                        } else {
+                            " "
+                        };
+                        let project = task
+                            .project
+                            .as_deref()
+                            .map(|p| format!(" [{p}]"))
+                            .unwrap_or_default();
+                        println!("  {marker} {:<24} {}{}", task.id, task.title, project);
+                    }
+                    println!();
+                }
+            }
+        }
     }
 
     Ok(())
@@ -2627,6 +2757,74 @@ fn handle_batch_command(
                 &filter_set,
                 reason.as_deref(),
                 dry_run,
+            );
+            print!("{}", summary.display());
+        }
+
+        BatchCommands::Merge {
+            canonical,
+            merge,
+            dry_run,
+        } => {
+            if merge.is_empty() {
+                eprintln!("Error: at least one --merge ID is required");
+                std::process::exit(1);
+            }
+            let summary = mem::batch_ops::duplicates::batch_merge(
+                graph, pkb_root, &canonical, &merge, dry_run,
+            );
+            print!("{}", summary.display());
+        }
+
+        BatchCommands::CreateEpics {
+            from,
+            parent,
+            project,
+            dry_run,
+        } => {
+            let content = std::fs::read_to_string(&from)
+                .unwrap_or_else(|e| {
+                    eprintln!("Error reading {from}: {e}");
+                    std::process::exit(1);
+                });
+
+            #[derive(serde::Deserialize)]
+            struct EpicsFile {
+                #[serde(default)]
+                parent: Option<String>,
+                #[serde(default)]
+                project: Option<String>,
+                epics: Vec<mem::batch_ops::epics::EpicDef>,
+            }
+
+            let file: EpicsFile = serde_yaml::from_str(&content)
+                .unwrap_or_else(|e| {
+                    eprintln!("Error parsing YAML: {e}");
+                    std::process::exit(1);
+                });
+
+            // CLI args override file-level defaults
+            let parent = parent.as_deref().or(file.parent.as_deref());
+            let project = project.as_deref().or(file.project.as_deref());
+
+            let summary = mem::batch_ops::epics::batch_create_epics(
+                graph, pkb_root, parent, project, &file.epics, dry_run,
+            );
+            print!("{}", summary.display());
+        }
+
+        BatchCommands::Reclassify {
+            new_type,
+            dry_run,
+            filters,
+        } => {
+            let filter_set = to_filter_set(&filters);
+            if filter_set.is_empty() {
+                eprintln!("Error: at least one filter is required for batch reclassify");
+                std::process::exit(1);
+            }
+            let summary = mem::batch_ops::reclassify::batch_reclassify(
+                graph, pkb_root, &filter_set, &new_type, dry_run,
             );
             print!("{}", summary.display());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared library for pkb (MCP server) and aops (CLI) binaries.
 
+pub mod batch_ops;
 pub mod distance;
 pub mod document_crud;
 pub mod embeddings;

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -2203,6 +2203,132 @@ impl PkbSearchServer {
         let json = serde_json::to_string_pretty(&stats).unwrap_or_default();
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
+
+    fn handle_find_duplicates(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
+        let filters = crate::batch_ops::filters::parse_filter_set(args);
+        let mode_str = args.get("mode").and_then(|v| v.as_str()).unwrap_or("both");
+        let mode = crate::batch_ops::duplicates::DuplicateMode::from_str(mode_str);
+        let title_threshold = args.get("title_threshold").and_then(|v| v.as_f64()).unwrap_or(0.7);
+        let semantic_threshold = args.get("similarity_threshold").and_then(|v| v.as_f64()).unwrap_or(0.85);
+
+        let graph = self.graph.read();
+        let store = self.store.read();
+        let report = crate::batch_ops::duplicates::find_duplicates(
+            &graph, &store, &filters, mode, title_threshold, semantic_threshold,
+        );
+        drop(graph);
+        drop(store);
+
+        let json = serde_json::to_string_pretty(&report).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    fn handle_batch_merge(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
+        let canonical = args
+            .get("canonical")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("canonical is required"),
+                data: None,
+            })?
+            .to_string();
+
+        let merge_ids: Vec<String> = args
+            .get("merge_ids")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+            .unwrap_or_default();
+
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        if merge_ids.is_empty() {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("merge_ids must contain at least one ID"),
+                data: None,
+            });
+        }
+
+        let graph = self.graph.read();
+        let summary = crate::batch_ops::duplicates::batch_merge(
+            &graph, &self.pkb_root, &canonical, &merge_ids, dry_run,
+        );
+        drop(graph);
+
+        if !dry_run && summary.changed > 0 {
+            self.rebuild_graph();
+        }
+
+        let json = serde_json::to_string_pretty(&summary).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    fn handle_batch_create_epics(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
+        let parent = args.get("parent").and_then(|v| v.as_str());
+        let project = args.get("project").and_then(|v| v.as_str());
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        let epics: Vec<crate::batch_ops::epics::EpicDef> = args
+            .get("epics")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        if epics.is_empty() {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("epics array is required and must not be empty"),
+                data: None,
+            });
+        }
+
+        let graph = self.graph.read();
+        let summary = crate::batch_ops::epics::batch_create_epics(
+            &graph, &self.pkb_root, parent, project, &epics, dry_run,
+        );
+        drop(graph);
+
+        if !dry_run && summary.changed > 0 {
+            self.rebuild_graph();
+        }
+
+        let json = serde_json::to_string_pretty(&summary).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    fn handle_batch_reclassify(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
+        let filters = crate::batch_ops::filters::parse_filter_set(args);
+        let new_type = args
+            .get("new_type")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("new_type is required"),
+                data: None,
+            })?;
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        if filters.is_empty() {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("At least one filter is required"),
+                data: None,
+            });
+        }
+
+        let graph = self.graph.read();
+        let summary = crate::batch_ops::reclassify::batch_reclassify(
+            &graph, &self.pkb_root, &filters, new_type, dry_run,
+        );
+        drop(graph);
+
+        if !dry_run && summary.changed > 0 {
+            self.rebuild_graph();
+        }
+
+        let json = serde_json::to_string_pretty(&summary).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
 }
 
 impl ServerHandler for PkbSearchServer {
@@ -2242,6 +2368,10 @@ impl ServerHandler for PkbSearchServer {
             "batch_reparent" => self.handle_batch_reparent(&args),
             "batch_archive" => self.handle_batch_archive(&args),
             "graph_stats" => self.handle_graph_stats(&args),
+            "find_duplicates" => self.handle_find_duplicates(&args),
+            "batch_merge" => self.handle_batch_merge(&args),
+            "batch_create_epics" => self.handle_batch_create_epics(&args),
+            "batch_reclassify" => self.handle_batch_reclassify(&args),
             _ => Err(McpError {
                 code: ErrorCode::METHOD_NOT_FOUND,
                 message: Cow::from(format!("Unknown tool: {}", request.name)),
@@ -2721,6 +2851,84 @@ impl ServerHandler for PkbSearchServer {
                     "properties": {
                         "project": { "type": "string", "description": "Scope to a specific project" }
                     }
+                }))
+                .unwrap(),
+            ),
+            // ── Phase 2: Deduplication & Restructuring ────────────────────
+            Tool::new(
+                "find_duplicates",
+                "Detect potential duplicate tasks using title similarity and/or semantic embedding similarity. Returns clusters with suggested canonical task. Read-only.",
+                serde_json::from_value::<JsonObject>(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "project": { "type": "string", "description": "Filter by project" },
+                        "status": { "type": "string", "description": "Filter by status" },
+                        "mode": { "type": "string", "description": "Detection mode: title, semantic, or both (default: both)" },
+                        "title_threshold": { "type": "number", "description": "Title similarity threshold 0-1 (default: 0.7)" },
+                        "similarity_threshold": { "type": "number", "description": "Semantic similarity threshold 0-1 (default: 0.85)" }
+                    }
+                }))
+                .unwrap(),
+            ),
+            Tool::new(
+                "batch_merge",
+                "Merge duplicate tasks into a canonical task. Archives merged tasks with superseded_by, unions tags/deps, reparents children, updates backlinks.",
+                serde_json::from_value::<JsonObject>(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "canonical": { "type": "string", "description": "ID of the task to keep" },
+                        "merge_ids": { "type": "array", "items": { "type": "string" }, "description": "IDs of duplicates to merge into canonical" },
+                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: false)" }
+                    },
+                    "required": ["canonical", "merge_ids"]
+                }))
+                .unwrap(),
+            ),
+            Tool::new(
+                "batch_create_epics",
+                "Create multiple epic containers and reparent existing tasks under them. Primary tool for structuring a flat task list into organized groups.",
+                serde_json::from_value::<JsonObject>(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "parent": { "type": "string", "description": "Parent for all new epics" },
+                        "project": { "type": "string", "description": "Project field for all new epics" },
+                        "epics": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "title": { "type": "string" },
+                                    "id": { "type": "string" },
+                                    "priority": { "type": "integer" },
+                                    "task_ids": { "type": "array", "items": { "type": "string" } },
+                                    "depends_on": { "type": "array", "items": { "type": "string" } },
+                                    "body": { "type": "string" }
+                                },
+                                "required": ["title", "task_ids"]
+                            },
+                            "description": "Array of epic definitions with title and task_ids to reparent"
+                        },
+                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: false)" }
+                    },
+                    "required": ["epics"]
+                }))
+                .unwrap(),
+            ),
+            Tool::new(
+                "batch_reclassify",
+                "Change the type field of matching tasks and move files to the correct subdirectory. Use for fixing memories filed as tasks and vice versa.",
+                serde_json::from_value::<JsonObject>(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "ids": { "type": "array", "items": { "type": "string" }, "description": "Explicit task IDs" },
+                        "project": { "type": "string", "description": "Filter by project" },
+                        "status": { "type": "string", "description": "Filter by status" },
+                        "type": { "type": "string", "description": "Filter by current type" },
+                        "title_contains": { "type": "string", "description": "Filter by title substring" },
+                        "new_type": { "type": "string", "description": "New document type (task, memory, note, knowledge, project, epic, goal)" },
+                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: false)" }
+                    },
+                    "required": ["new_type"]
                 }))
                 .unwrap(),
             ),

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -2107,6 +2107,102 @@ impl PkbSearchServer {
             path.display()
         ))]))
     }
+
+    // =========================================================================
+    // BATCH OPERATIONS
+    // =========================================================================
+
+    fn handle_batch_update(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
+        let filters = crate::batch_ops::filters::parse_filter_set(args);
+        let updates = args.get("updates").cloned().unwrap_or(JsonValue::Object(serde_json::Map::new()));
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        if filters.is_empty() && updates.as_object().map(|m| m.is_empty()).unwrap_or(true) {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("At least one filter and one update field required"),
+                data: None,
+            });
+        }
+
+        let graph = self.graph.read();
+        let summary = crate::batch_ops::update::batch_update(&graph, &self.pkb_root, &filters, &updates, dry_run);
+        drop(graph);
+
+        if !dry_run && summary.changed > 0 {
+            self.rebuild_graph();
+        }
+
+        let json = serde_json::to_string_pretty(&summary).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    fn handle_batch_reparent(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
+        let new_parent = args
+            .get("new_parent")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("new_parent is required"),
+                data: None,
+            })?
+            .to_string();
+
+        let filters = crate::batch_ops::filters::parse_filter_set(args);
+        let update_project = args.get("update_project").and_then(|v| v.as_bool()).unwrap_or(true);
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        let graph = self.graph.read();
+        let summary = crate::batch_ops::reparent::batch_reparent(
+            &graph, &self.pkb_root, &filters, &new_parent, update_project, dry_run,
+        );
+        drop(graph);
+
+        if !dry_run && summary.changed > 0 {
+            self.rebuild_graph();
+        }
+
+        let json = serde_json::to_string_pretty(&summary).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    fn handle_batch_archive(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
+        let filters = crate::batch_ops::filters::parse_filter_set(args);
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(true); // default true!
+        let reason = args.get("reason").and_then(|v| v.as_str());
+
+        if filters.is_empty() {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("At least one filter is required for batch archive"),
+                data: None,
+            });
+        }
+
+        let graph = self.graph.read();
+        let summary = crate::batch_ops::update::batch_archive(
+            &graph, &self.pkb_root, &filters, reason, dry_run,
+        );
+        drop(graph);
+
+        if !dry_run && summary.changed > 0 {
+            self.rebuild_graph();
+        }
+
+        let json = serde_json::to_string_pretty(&summary).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    fn handle_graph_stats(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
+        let project = args.get("project").and_then(|v| v.as_str());
+
+        let graph = self.graph.read();
+        let stats = crate::batch_ops::stats::graph_stats(&graph, project);
+        drop(graph);
+
+        let json = serde_json::to_string_pretty(&stats).unwrap_or_default();
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
 }
 
 impl ServerHandler for PkbSearchServer {
@@ -2142,6 +2238,10 @@ impl ServerHandler for PkbSearchServer {
             "pkb_context" => self.handle_pkb_context(&args),
             "pkb_trace" => self.handle_pkb_trace(&args),
             "pkb_orphans" => self.handle_pkb_orphans(&args),
+            "batch_update" => self.handle_batch_update(&args),
+            "batch_reparent" => self.handle_batch_reparent(&args),
+            "batch_archive" => self.handle_batch_archive(&args),
+            "graph_stats" => self.handle_graph_stats(&args),
             _ => Err(McpError {
                 code: ErrorCode::METHOD_NOT_FOUND,
                 message: Cow::from(format!("Unknown tool: {}", request.name)),
@@ -2534,6 +2634,92 @@ impl ServerHandler for PkbSearchServer {
                         "limit": { "type": "integer", "description": "Max results (default: all). Set to 0 for unlimited." },
                         "types": { "type": "array", "items": { "type": "string" }, "description": "Filter by node type (e.g. [\"task\"], [\"task\", \"project\"]). Omit for all types." },
                         "project": { "type": "string", "description": "Filter by project" }
+                    }
+                }))
+                .unwrap(),
+            ),
+            // ── Batch Operations ──────────────────────────────────────────
+            Tool::new(
+                "batch_update",
+                "Update frontmatter fields across multiple tasks in one operation. Supports filtered selection (by project, priority, tags, age, etc.) or explicit ID lists. Use _add_tags/_remove_tags for array manipulation. Set dry_run=true to preview changes.",
+                serde_json::from_value::<JsonObject>(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "ids": { "type": "array", "items": { "type": "string" }, "description": "Explicit task IDs (flexible resolution)" },
+                        "project": { "type": "string", "description": "Filter by project" },
+                        "parent": { "type": "string", "description": "Filter: direct children of parent" },
+                        "subtree": { "type": "string", "description": "Filter: all descendants of node" },
+                        "status": { "type": "string", "description": "Filter by status" },
+                        "priority": { "type": "integer", "description": "Filter by exact priority" },
+                        "priority_gte": { "type": "integer", "description": "Filter: priority >= N" },
+                        "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter: has ALL listed tags" },
+                        "type": { "type": "string", "description": "Filter by document type" },
+                        "older_than_days": { "type": "integer", "description": "Filter: created > N days ago" },
+                        "stale_days": { "type": "integer", "description": "Filter: not modified in N days" },
+                        "orphan": { "type": "boolean", "description": "Filter: no parent and no project" },
+                        "title_contains": { "type": "string", "description": "Filter: title substring (case-insensitive)" },
+                        "directory": { "type": "string", "description": "Filter: file path contains directory" },
+                        "weight_gte": { "type": "integer", "description": "Filter: downstream weight >= N" },
+                        "updates": { "type": "object", "description": "Fields to set (null to remove). Special keys: _add_tags, _remove_tags, _add_depends_on, _remove_depends_on" },
+                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: false)" }
+                    },
+                    "required": ["updates"]
+                }))
+                .unwrap(),
+            ),
+            Tool::new(
+                "batch_reparent",
+                "Move multiple tasks to a new parent in one operation. Use when restructuring the task graph — grouping flat tasks into epics, or reorganizing tasks between projects. Cascades parent's project field by default.",
+                serde_json::from_value::<JsonObject>(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "ids": { "type": "array", "items": { "type": "string" }, "description": "Explicit task IDs" },
+                        "project": { "type": "string", "description": "Filter by project" },
+                        "parent": { "type": "string", "description": "Filter: direct children of parent" },
+                        "subtree": { "type": "string", "description": "Filter: all descendants of node" },
+                        "status": { "type": "string", "description": "Filter by status" },
+                        "priority": { "type": "integer", "description": "Filter by exact priority" },
+                        "priority_gte": { "type": "integer", "description": "Filter: priority >= N" },
+                        "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter: has ALL listed tags" },
+                        "title_contains": { "type": "string", "description": "Filter: title substring" },
+                        "new_parent": { "type": "string", "description": "ID of new parent (flexible resolution)" },
+                        "update_project": { "type": "boolean", "description": "Cascade parent's project field (default: true)" },
+                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: false)" }
+                    },
+                    "required": ["new_parent"]
+                }))
+                .unwrap(),
+            ),
+            Tool::new(
+                "batch_archive",
+                "Archive multiple tasks (set status=done). Dry-run by default for safety — set dry_run=false to execute. Warns about in_progress tasks and those with active children.",
+                serde_json::from_value::<JsonObject>(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "ids": { "type": "array", "items": { "type": "string" }, "description": "Explicit task IDs" },
+                        "project": { "type": "string", "description": "Filter by project" },
+                        "parent": { "type": "string", "description": "Filter: direct children of parent" },
+                        "subtree": { "type": "string", "description": "Filter: all descendants of node" },
+                        "status": { "type": "string", "description": "Filter by status" },
+                        "priority": { "type": "integer", "description": "Filter by exact priority" },
+                        "priority_gte": { "type": "integer", "description": "Filter: priority >= N" },
+                        "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter: has ALL listed tags" },
+                        "older_than_days": { "type": "integer", "description": "Filter: created > N days ago" },
+                        "stale_days": { "type": "integer", "description": "Filter: not modified in N days" },
+                        "title_contains": { "type": "string", "description": "Filter: title substring" },
+                        "reason": { "type": "string", "description": "Archive reason (appended to task body)" },
+                        "dry_run": { "type": "boolean", "description": "Preview only (default: true — must explicitly set false to execute)" }
+                    }
+                }))
+                .unwrap(),
+            ),
+            Tool::new(
+                "graph_stats",
+                "Report on graph health: status/priority/type distributions, orphan count, stale tasks, disconnected epics, and more. Read-only, no mutations.",
+                serde_json::from_value::<JsonObject>(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "project": { "type": "string", "description": "Scope to a specific project" }
                     }
                 }))
                 .unwrap(),

--- a/src/vectordb.rs
+++ b/src/vectordb.rs
@@ -385,6 +385,16 @@ impl VectorStore {
         results
     }
 
+    /// Iterate over all document entries (for pairwise comparison in duplicate detection).
+    pub fn documents(&self) -> impl Iterator<Item = (&String, &DocumentEntry)> {
+        self.documents.iter()
+    }
+
+    /// Get a document entry by its relative path key.
+    pub fn get_entry(&self, path: &str) -> Option<&DocumentEntry> {
+        self.documents.get(path)
+    }
+
     /// List all tags across all documents with their occurrence counts.
     pub fn list_all_tags(&self) -> HashMap<String, usize> {
         let mut tags: HashMap<String, usize> = HashMap::new();


### PR DESCRIPTION
## Summary

- Add `src/batch_ops/` module with FilterSet (17 composable filters), BatchContext (deferred-rebuild pattern), and core operations
- **batch_update**: bulk frontmatter updates with special array manipulation (_add_tags, _remove_tags, _add_depends_on, _remove_depends_on, superseded_by)
- **batch_reparent**: move tasks to new parent with project cascade, idempotency checks
- **batch_archive**: convenience wrapper with dry-run-by-default safety, warnings for in_progress/active children
- **graph_stats**: read-only health report (status/priority/type distributions, orphans, stale, empty epics)
- CLI surface: `aops batch update/reparent/archive`, `aops graph-stats`
- MCP surface: 4 new tools (batch_update, batch_reparent, batch_archive, graph_stats)

Implements Phase 1 of the batch graph operations spec (`docs/specs/batch-graph-operations.md`).

Task: aops-dd84cde4

## Test plan

- [x] All 67 existing tests pass
- [x] 4 new unit tests for FilterSet (describe, empty, is_older_than, parse)
- [x] Live smoke test: `aops graph-stats` reports correct stats for 1803-task graph
- [x] Live smoke test: `aops batch update --dry-run` correctly matches and skips idempotent changes
- [x] Live smoke test: `aops batch reparent --dry-run` correctly resolves targets
- [x] Live smoke test: `aops batch archive` defaults to dry-run mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)