### PR TITLE
fix(dashboard): QA improvements to overwhelm dash main page

### DIFF
--- a/overwhelm-dashboard/src/lib/components/dashboard/ActiveSessions.svelte
+++ b/overwhelm-dashboard/src/lib/components/dashboard/ActiveSessions.svelte
@@ -59,7 +59,10 @@
             </div>
         {/each}
         {#if sessions.length === 0}
-            <div class="text-xs text-primary/40 italic">No active agent sessions in the last 4 hours.</div>
+            <div class="flex items-center gap-3 text-xs text-primary/50 py-2">
+                <span class="material-symbols-outlined text-[16px] text-primary/30">nights_stay</span>
+                All quiet — no active sessions right now.
+            </div>
         {/if}
     </div>
 

--- a/overwhelm-dashboard/src/lib/components/dashboard/DashboardView.svelte
+++ b/overwhelm-dashboard/src/lib/components/dashboard/DashboardView.svelte
@@ -27,7 +27,6 @@
     $: droppedFromGraph = $graphData ? $graphData.nodes
         .filter(n => n.type === 'task' && ['active', 'in_progress'].includes(n.status) && n._raw?.created)
         .filter(n => {
-            // Tasks older than 3 days with no recent modification are "dropped"
             const created = new Date(n._raw.created).getTime();
             const modified = n._raw?.modified ? new Date(n._raw.modified).getTime() : created;
             const daysSinceModified = (Date.now() - modified) / 86400000;
@@ -47,7 +46,6 @@
 
     $: pathData = data?.dashboardData?.path || { threads: [], abandoned_work: [] };
     $: {
-        // Enrich path data with graph-derived dropped threads if none from summaries
         if (pathData.abandoned_work.length === 0 && droppedFromGraph.length > 0) {
             pathData = { ...pathData, abandoned_work: droppedFromGraph };
         }
@@ -59,7 +57,6 @@
         const serverData = data?.dashboardData?.project_data || { meta: {}, tasks: {}, accomplishments: {}, sessions: {} };
         const result: any = { meta: { ...serverData.meta }, tasks: {}, accomplishments: { ...serverData.accomplishments }, sessions: { ...serverData.sessions } };
 
-        // Build tasks per project from graph data
         const gd = $graphData;
         for (const proj of projects) {
             if (!proj) continue;
@@ -70,10 +67,8 @@
             );
             result.tasks[p] = projTasks.length > 0 ? projTasks : (serverData.tasks?.[p] || []);
 
-            // Ensure meta exists
             if (!result.meta[p]) result.meta[p] = {};
 
-            // Build epics from graph data
             const projEpics = gd.nodes.filter((n: any) =>
                 n.type === 'epic' && n.project === p &&
                 !['done', 'completed', 'cancelled'].includes(n.status)
@@ -86,7 +81,6 @@
                 });
             }
 
-            // Accomplishments: also pull done tasks from graph as fallback
             if (!result.accomplishments[p] || result.accomplishments[p].length === 0) {
                 const doneTasks = gd.nodes
                     .filter((n: any) => n.type === 'task' && n.project === p && ['done', 'completed'].includes(n.status))
@@ -97,7 +91,6 @@
                 }
             }
 
-            // Sessions
             if (!result.sessions[p]) result.sessions[p] = [];
         }
 
@@ -108,8 +101,11 @@
         (data?.dashboardData?.project_projects || []);
 </script>
 
+<!-- Floating Quick Capture — always accessible -->
+<QuickCapture />
+
 <div class="h-full p-8 font-mono text-primary flex flex-col gap-6">
-    <!-- PRIORITY 1: What's running + what needs you (above the fold) -->
+    <!-- PRIORITY 1: What's running + what needs you -->
     <div class="border border-primary/30 bg-surface p-4">
         <ActiveSessions
             sessions={activeSessionsData}
@@ -128,15 +124,23 @@
         />
     </div>
 
-    <!-- PRIORITY 3: Dropped threads (most actionable for ADHD context recovery) -->
-    {#if pathData.abandoned_work?.length > 0 || pathData.threads?.length > 0}
+    <!-- PRIORITY 3: Dropped threads — promoted to standalone section -->
+    {#if pathData.abandoned_work?.length > 0}
         <div class="border border-yellow-500/30 bg-surface p-4">
+            <PathTimeline path={pathData} abandonedOnly={true} />
+        </div>
+    {/if}
+
+    <!-- PRIORITY 4: Session history (gated, collapsed by default) -->
+    {#if pathData.threads?.length > 0}
+        <div class="border border-primary/30 bg-surface p-4">
             <PathTimeline path={pathData} />
         </div>
     {/if}
 
-    <div class="grid grid-cols-12 gap-6 flex-1 min-h-0">
-        <div class="col-span-8 flex flex-col gap-6 overflow-y-auto custom-scrollbar pr-2">
+    <!-- PRIORITY 5: Project details + sessions — use auto height, not flex-1 -->
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
+        <div class="lg:col-span-8 flex flex-col gap-6">
             <div class="border border-primary/30 bg-surface p-4">
                 <RecentSessions synthesis={data?.dashboardData?.synthesis} />
             </div>
@@ -149,18 +153,16 @@
             </div>
         </div>
 
-        <div class="col-span-4 flex flex-col gap-6 overflow-y-auto custom-scrollbar pr-2 bg-black/40 p-4 border border-primary/20 rounded-xl">
-            <div class="border border-primary/30 bg-surface p-4 shadow-lg">
-                <QuickCapture />
-            </div>
-
-            <div class="border border-primary/30 bg-surface p-4 shadow-lg">
-                <SynthesisPanel
-                    synthesis={data?.dashboardData?.synthesis}
-                    dailyStory={null}
-                    inline={false}
-                />
-            </div>
+        <div class="lg:col-span-4 flex flex-col gap-6 bg-black/40 p-4 border border-primary/20 rounded-xl">
+            {#if data?.dashboardData?.synthesis?.blockers || data?.dashboardData?.synthesis?.recent_context}
+                <div class="border border-primary/30 bg-surface p-4 shadow-lg">
+                    <SynthesisPanel
+                        synthesis={data?.dashboardData?.synthesis}
+                        dailyStory={null}
+                        inline={false}
+                    />
+                </div>
+            {/if}
         </div>
     </div>
 </div>

--- a/overwhelm-dashboard/src/lib/components/dashboard/DashboardView.svelte
+++ b/overwhelm-dashboard/src/lib/components/dashboard/DashboardView.svelte
@@ -131,8 +131,8 @@
         </div>
     {/if}
 
-    <!-- PRIORITY 4: Session history (gated, collapsed by default) -->
-    {#if pathData.threads?.length > 0}
+    <!-- PRIORITY 4: Recent activity feed (what happened, by project) -->
+    {#if pathData.activity?.length > 0}
         <div class="border border-primary/30 bg-surface p-4">
             <PathTimeline path={pathData} />
         </div>

--- a/overwhelm-dashboard/src/lib/components/dashboard/PathTimeline.svelte
+++ b/overwhelm-dashboard/src/lib/components/dashboard/PathTimeline.svelte
@@ -1,91 +1,163 @@
 <script lang="ts">
     export let path: any;
+    /** When true, only render the abandoned work section (for standalone placement) */
+    export let abandonedOnly: boolean = false;
 
     $: threads = path?.threads || [];
     $: abandoned = path?.abandoned_work || [];
+
+    // Group threads by project so same-project goals don't break the flow
+    $: groupedByProject = (() => {
+        const groups: { project: string; threads: any[] }[] = [];
+        for (const thread of threads) {
+            const proj = thread.project || 'unknown';
+            const last = groups[groups.length - 1];
+            if (last && last.project === proj) {
+                last.threads.push(thread);
+            } else {
+                groups.push({ project: proj, threads: [thread] });
+            }
+        }
+        return groups;
+    })();
+
+    const INITIAL_GROUPS = 5;
+    let showAllGroups = false;
+    $: visibleGroups = showAllGroups ? groupedByProject : groupedByProject.slice(0, INITIAL_GROUPS);
+    $: hiddenGroupCount = Math.max(0, groupedByProject.length - INITIAL_GROUPS);
+
+    // Track which project groups have their events expanded
+    let expandedGroups: Set<number> = new Set();
+    function toggleGroup(idx: number) {
+        if (expandedGroups.has(idx)) {
+            expandedGroups.delete(idx);
+        } else {
+            expandedGroups.add(idx);
+        }
+        expandedGroups = expandedGroups;
+    }
 
     function formatTime(isoString: string): string {
         if (!isoString) return "";
         try {
             const d = new Date(isoString);
-            return d.toLocaleTimeString([], {
-                hour: "2-digit",
-                minute: "2-digit",
-            });
+            return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
         } catch {
             return isoString;
         }
     }
+
+    function totalEvents(group: { threads: any[] }): number {
+        return group.threads.reduce((sum, t) => sum + (t.events?.length || 0), 0);
+    }
 </script>
 
-{#if threads.length > 0 || abandoned.length > 0}
-    <div class="flex flex-col gap-6 font-mono text-primary">
-        <h3 class="text-xs font-bold tracking-[0.2em] text-primary/80 border-b border-primary/30 pb-2">PATH RECONSTRUCTION</h3>
-
-        {#if abandoned.length > 0}
-            <div class="flex flex-col gap-3 p-4 border border-yellow-500/30 bg-yellow-900/10">
-                <h4 class="text-xs font-bold text-yellow-500 tracking-widest flex items-center gap-2">
-                    <span class="material-symbols-outlined text-[14px]">warning</span>
-                    ABANDONED WORK DETECTED
-                </h4>
-                <div class="flex flex-col gap-2">
-                    {#each abandoned as item}
-                        <div class="flex flex-col gap-1 border-l-2 border-yellow-500/50 pl-3">
-                            <div class="flex items-center gap-2">
-                                <span class="text-[10px] font-bold bg-yellow-500/20 text-yellow-500 px-1.5 py-0.5">{item.project || "UNKNOWN"}</span>
-                                <span class="text-[10px] text-yellow-500/60">{item.time_ago || ""}</span>
-                            </div>
-                            <div class="text-xs text-yellow-500/90">{item.description}</div>
+{#if abandonedOnly}
+    <!-- Standalone abandoned work section -->
+    {#if abandoned.length > 0}
+        <div class="flex flex-col gap-3 font-mono">
+            <h3 class="text-xs font-bold tracking-[0.2em] text-yellow-500/80 border-b border-yellow-500/30 pb-2 flex items-center gap-2">
+                <span class="material-symbols-outlined text-[14px]">warning</span>
+                DROPPED THREADS ({abandoned.length})
+            </h3>
+            <div class="flex flex-col gap-2">
+                {#each abandoned as item}
+                    <div class="flex flex-col gap-1 border-l-2 border-yellow-500/50 pl-3">
+                        <div class="flex items-center gap-2">
+                            <span class="text-[10px] font-bold bg-yellow-500/20 text-yellow-500 px-1.5 py-0.5">{item.project || "UNKNOWN"}</span>
+                            <span class="text-[10px] text-yellow-500/60">{item.time_ago || ""}</span>
                         </div>
-                    {/each}
-                </div>
-            </div>
-        {/if}
-
-        <div class="flex flex-col gap-6">
-            {#each threads as thread}
-                <div class="flex flex-col gap-3">
-                    <div class="flex items-center gap-3 text-xs">
-                        <span class="font-bold bg-primary/20 text-primary px-2 py-0.5 border border-primary/30">{thread.project}</span>
-                        {#if thread.git_branch}
-                            <span class="text-primary/70 flex items-center gap-1"><span class="material-symbols-outlined text-[14px]">fork_right</span> {thread.git_branch}</span>
-                        {/if}
-                        <span class="text-[10px] text-primary/40 ml-auto">{thread.session_id}</span>
+                        <div class="text-xs text-yellow-500/90">{item.description}</div>
                     </div>
+                {/each}
+            </div>
+        </div>
+    {/if}
 
-                    {#if thread.initial_goal || thread.hydrated_intent}
-                        <div class="bg-black/40 border border-primary/20 p-3 text-xs leading-relaxed">
-                            <strong class="text-primary/60">GOAL:</strong>
-                            <span class="text-primary/90">{thread.hydrated_intent || thread.initial_goal}</span>
+{:else if threads.length > 0}
+    <!-- Full path reconstruction with gating -->
+    <div class="flex flex-col gap-4 font-mono text-primary">
+        <h3 class="text-xs font-bold tracking-[0.2em] text-primary/80 border-b border-primary/30 pb-2">
+            PATH RECONSTRUCTION
+            <span class="text-primary/40 font-normal ml-2">({threads.length} sessions across {groupedByProject.length} projects)</span>
+        </h3>
+
+        <div class="flex flex-col gap-4">
+            {#each visibleGroups as group, groupIdx}
+                {@const eventCount = totalEvents(group)}
+                {@const goalCount = group.threads.length}
+                {@const isExpanded = expandedGroups.has(groupIdx)}
+                <div class="flex flex-col gap-2">
+                    <!-- Project header — click to expand/collapse events -->
+                    <button
+                        class="flex items-center gap-3 text-xs cursor-pointer hover:bg-primary/5 p-1 -m-1 transition-colors rounded text-left w-full"
+                        on:click={() => toggleGroup(groupIdx)}
+                    >
+                        <span class="font-bold bg-primary/20 text-primary px-2 py-0.5 border border-primary/30">{group.project}</span>
+                        <span class="text-primary/40">{goalCount} goal{goalCount !== 1 ? 's' : ''}, {eventCount} event{eventCount !== 1 ? 's' : ''}</span>
+                        <span class="material-symbols-outlined text-[14px] text-primary/40 ml-auto">{isExpanded ? 'expand_less' : 'expand_more'}</span>
+                    </button>
+
+                    <!-- Collapsed: just goal summaries -->
+                    {#if !isExpanded}
+                        <div class="flex flex-col gap-1 ml-4">
+                            {#each group.threads as thread}
+                                {#if thread.initial_goal || thread.hydrated_intent}
+                                    <div class="text-xs text-primary/60 truncate">
+                                        <span class="text-primary/40">›</span>
+                                        {thread.hydrated_intent || thread.initial_goal}
+                                    </div>
+                                {/if}
+                            {/each}
+                        </div>
+                    {:else}
+                        <!-- Expanded: full timeline -->
+                        <div class="flex flex-col gap-0 ml-2 border-l border-primary/20 pl-4 relative">
+                            {#each group.threads as thread}
+                                {#if thread.initial_goal || thread.hydrated_intent}
+                                    <div class="relative py-3 -ml-4 pl-4 pr-2">
+                                        <div class="absolute left-[-4.5px] top-[18px] w-2 h-2 rounded-full bg-primary"></div>
+                                        <div class="bg-black/40 border border-primary/20 p-3 text-xs leading-relaxed">
+                                            <strong class="text-primary/60">GOAL:</strong>
+                                            <span class="text-primary/90">{thread.hydrated_intent || thread.initial_goal}</span>
+                                        </div>
+                                    </div>
+                                {/if}
+
+                                {#each thread.events as event}
+                                    <div class="relative py-3 group hover:bg-primary/5 -ml-4 pl-4 pr-2 transition-colors">
+                                        <div class="absolute left-[-4.5px] top-[18px] w-2 h-2 rounded-full bg-black border border-primary group-hover:bg-primary transition-colors"></div>
+                                        <div class="flex items-start gap-4">
+                                            <div class="text-[10px] text-primary/50 pt-0.5 w-12 shrink-0">
+                                                {formatTime(event.timestamp)}
+                                            </div>
+                                            <div class="flex flex-col gap-1 flex-1">
+                                                <div class="text-xs text-primary/80 leading-relaxed">
+                                                    {event.narrative}
+                                                </div>
+                                                {#if event.task_id}
+                                                    <div class="text-[10px] text-primary/40 mt-1">
+                                                        ID: {event.task_id}
+                                                    </div>
+                                                {/if}
+                                            </div>
+                                        </div>
+                                    </div>
+                                {/each}
+                            {/each}
                         </div>
                     {/if}
-
-                    <div class="flex flex-col gap-0 ml-2 border-l border-primary/20 pl-4 relative">
-                        {#each thread.events as event}
-                            <div class="relative py-3 group hover:bg-primary/5 -ml-4 pl-4 pr-2 transition-colors">
-                                <!-- Marker -->
-                                <div class="absolute left-[-4.5px] top-[18px] w-2 h-2 rounded-full bg-black border border-primary group-hover:bg-primary transition-colors"></div>
-
-                                <div class="flex items-start gap-4">
-                                    <div class="text-[10px] text-primary/50 pt-0.5 w-12 shrink-0">
-                                        {formatTime(event.timestamp)}
-                                    </div>
-                                    <div class="flex flex-col gap-1 flex-1">
-                                        <div class="text-xs text-primary/80 leading-relaxed">
-                                            {event.narrative}
-                                        </div>
-                                        {#if event.task_id}
-                                            <div class="text-[10px] text-primary/40 mt-1">
-                                                ID: {event.task_id}
-                                            </div>
-                                        {/if}
-                                    </div>
-                                </div>
-                            </div>
-                        {/each}
-                    </div>
                 </div>
             {/each}
         </div>
+
+        {#if !showAllGroups && hiddenGroupCount > 0}
+            <button
+                class="text-xs text-primary/50 hover:text-primary transition-colors cursor-pointer border border-primary/20 hover:border-primary/40 px-3 py-2 text-center"
+                on:click={() => showAllGroups = true}
+            >
+                Show {hiddenGroupCount} more project{hiddenGroupCount !== 1 ? 's' : ''}...
+            </button>
+        {/if}
     </div>
 {/if}

--- a/overwhelm-dashboard/src/lib/components/dashboard/PathTimeline.svelte
+++ b/overwhelm-dashboard/src/lib/components/dashboard/PathTimeline.svelte
@@ -1,59 +1,32 @@
 <script lang="ts">
     export let path: any;
-    /** When true, only render the abandoned work section (for standalone placement) */
+    /** When true, only render the abandoned work section */
     export let abandonedOnly: boolean = false;
 
-    $: threads = path?.threads || [];
+    $: activity = path?.activity || [];
     $: abandoned = path?.abandoned_work || [];
 
-    // Group threads by project so same-project goals don't break the flow
-    $: groupedByProject = (() => {
-        const groups: { project: string; threads: any[] }[] = [];
-        for (const thread of threads) {
-            const proj = thread.project || 'unknown';
-            const last = groups[groups.length - 1];
-            if (last && last.project === proj) {
-                last.threads.push(thread);
-            } else {
-                groups.push({ project: proj, threads: [thread] });
-            }
-        }
-        return groups;
-    })();
+    const INITIAL_PROJECTS = 8;
+    let showAll = false;
+    $: visible = showAll ? activity : activity.slice(0, INITIAL_PROJECTS);
+    $: hiddenCount = Math.max(0, activity.length - INITIAL_PROJECTS);
 
-    const INITIAL_GROUPS = 5;
-    let showAllGroups = false;
-    $: visibleGroups = showAllGroups ? groupedByProject : groupedByProject.slice(0, INITIAL_GROUPS);
-    $: hiddenGroupCount = Math.max(0, groupedByProject.length - INITIAL_GROUPS);
-
-    // Track which project groups have their events expanded
-    let expandedGroups: Set<number> = new Set();
-    function toggleGroup(idx: number) {
-        if (expandedGroups.has(idx)) {
-            expandedGroups.delete(idx);
-        } else {
-            expandedGroups.add(idx);
-        }
-        expandedGroups = expandedGroups;
+    function outcomeIcon(outcome: string): string {
+        if (outcome === 'success') return '✓';
+        if (outcome === 'in_progress' || outcome === 'partial') return '↻';
+        if (outcome === 'failure' || outcome === 'error') return '✗';
+        return '·';
     }
 
-    function formatTime(isoString: string): string {
-        if (!isoString) return "";
-        try {
-            const d = new Date(isoString);
-            return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-        } catch {
-            return isoString;
-        }
-    }
-
-    function totalEvents(group: { threads: any[] }): number {
-        return group.threads.reduce((sum, t) => sum + (t.events?.length || 0), 0);
+    function outcomeClass(outcome: string): string {
+        if (outcome === 'success') return 'text-green-500';
+        if (outcome === 'in_progress' || outcome === 'partial') return 'text-primary/60';
+        if (outcome === 'failure' || outcome === 'error') return 'text-red-500';
+        return 'text-primary/40';
     }
 </script>
 
 {#if abandonedOnly}
-    <!-- Standalone abandoned work section -->
     {#if abandoned.length > 0}
         <div class="flex flex-col gap-3 font-mono">
             <h3 class="text-xs font-bold tracking-[0.2em] text-yellow-500/80 border-b border-yellow-500/30 pb-2 flex items-center gap-2">
@@ -74,89 +47,42 @@
         </div>
     {/if}
 
-{:else if threads.length > 0}
-    <!-- Full path reconstruction with gating -->
+{:else if activity.length > 0}
     <div class="flex flex-col gap-4 font-mono text-primary">
         <h3 class="text-xs font-bold tracking-[0.2em] text-primary/80 border-b border-primary/30 pb-2">
-            PATH RECONSTRUCTION
-            <span class="text-primary/40 font-normal ml-2">({threads.length} sessions across {groupedByProject.length} projects)</span>
+            RECENT ACTIVITY
+            <span class="text-primary/40 font-normal ml-2">({activity.length} projects)</span>
         </h3>
 
         <div class="flex flex-col gap-4">
-            {#each visibleGroups as group, groupIdx}
-                {@const eventCount = totalEvents(group)}
-                {@const goalCount = group.threads.length}
-                {@const isExpanded = expandedGroups.has(groupIdx)}
-                <div class="flex flex-col gap-2">
-                    <!-- Project header — click to expand/collapse events -->
-                    <button
-                        class="flex items-center gap-3 text-xs cursor-pointer hover:bg-primary/5 p-1 -m-1 transition-colors rounded text-left w-full"
-                        on:click={() => toggleGroup(groupIdx)}
-                    >
+            {#each visible as group}
+                <div class="flex flex-col gap-1.5">
+                    <div class="flex items-center gap-3 text-xs">
                         <span class="font-bold bg-primary/20 text-primary px-2 py-0.5 border border-primary/30">{group.project}</span>
-                        <span class="text-primary/40">{goalCount} goal{goalCount !== 1 ? 's' : ''}, {eventCount} event{eventCount !== 1 ? 's' : ''}</span>
-                        <span class="material-symbols-outlined text-[14px] text-primary/40 ml-auto">{isExpanded ? 'expand_less' : 'expand_more'}</span>
-                    </button>
+                        <span class="text-primary/30 ml-auto">{group.period}</span>
+                    </div>
 
-                    <!-- Collapsed: just goal summaries -->
-                    {#if !isExpanded}
-                        <div class="flex flex-col gap-1 ml-4">
-                            {#each group.threads as thread}
-                                {#if thread.initial_goal || thread.hydrated_intent}
-                                    <div class="text-xs text-primary/60 truncate">
-                                        <span class="text-primary/40">›</span>
-                                        {thread.hydrated_intent || thread.initial_goal}
-                                    </div>
-                                {/if}
-                            {/each}
-                        </div>
-                    {:else}
-                        <!-- Expanded: full timeline -->
-                        <div class="flex flex-col gap-0 ml-2 border-l border-primary/20 pl-4 relative">
-                            {#each group.threads as thread}
-                                {#if thread.initial_goal || thread.hydrated_intent}
-                                    <div class="relative py-3 -ml-4 pl-4 pr-2">
-                                        <div class="absolute left-[-4.5px] top-[18px] w-2 h-2 rounded-full bg-primary"></div>
-                                        <div class="bg-black/40 border border-primary/20 p-3 text-xs leading-relaxed">
-                                            <strong class="text-primary/60">GOAL:</strong>
-                                            <span class="text-primary/90">{thread.hydrated_intent || thread.initial_goal}</span>
-                                        </div>
-                                    </div>
-                                {/if}
-
-                                {#each thread.events as event}
-                                    <div class="relative py-3 group hover:bg-primary/5 -ml-4 pl-4 pr-2 transition-colors">
-                                        <div class="absolute left-[-4.5px] top-[18px] w-2 h-2 rounded-full bg-black border border-primary group-hover:bg-primary transition-colors"></div>
-                                        <div class="flex items-start gap-4">
-                                            <div class="text-[10px] text-primary/50 pt-0.5 w-12 shrink-0">
-                                                {formatTime(event.timestamp)}
-                                            </div>
-                                            <div class="flex flex-col gap-1 flex-1">
-                                                <div class="text-xs text-primary/80 leading-relaxed">
-                                                    {event.narrative}
-                                                </div>
-                                                {#if event.task_id}
-                                                    <div class="text-[10px] text-primary/40 mt-1">
-                                                        ID: {event.task_id}
-                                                    </div>
-                                                {/if}
-                                            </div>
-                                        </div>
-                                    </div>
-                                {/each}
-                            {/each}
-                        </div>
-                    {/if}
+                    <div class="flex flex-col gap-0.5 ml-1">
+                        {#each group.items.slice(0, 5) as item}
+                            <div class="flex items-start gap-2 text-xs py-0.5">
+                                <span class="{outcomeClass(item.outcome)} shrink-0 w-3 text-center">{outcomeIcon(item.outcome)}</span>
+                                <span class="text-primary/80 line-clamp-1">{item.text}</span>
+                            </div>
+                        {/each}
+                        {#if group.items.length > 5}
+                            <div class="text-[10px] text-primary/30 ml-5">+ {group.items.length - 5} more</div>
+                        {/if}
+                    </div>
                 </div>
             {/each}
         </div>
 
-        {#if !showAllGroups && hiddenGroupCount > 0}
+        {#if !showAll && hiddenCount > 0}
             <button
                 class="text-xs text-primary/50 hover:text-primary transition-colors cursor-pointer border border-primary/20 hover:border-primary/40 px-3 py-2 text-center"
-                on:click={() => showAllGroups = true}
+                on:click={() => showAll = true}
             >
-                Show {hiddenGroupCount} more project{hiddenGroupCount !== 1 ? 's' : ''}...
+                Show {hiddenCount} more project{hiddenCount !== 1 ? 's' : ''}...
             </button>
         {/if}
     </div>

--- a/overwhelm-dashboard/src/lib/components/dashboard/QuickCapture.svelte
+++ b/overwhelm-dashboard/src/lib/components/dashboard/QuickCapture.svelte
@@ -3,6 +3,17 @@
     let isSubmitting = false;
     let lastCreatedId: string | null = null;
     let errorMsg: string | null = null;
+    let isOpen = false;
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.altKey && e.key === 'c') {
+            e.preventDefault();
+            isOpen = !isOpen;
+        }
+        if (e.key === 'Escape' && isOpen) {
+            isOpen = false;
+        }
+    }
 
     async function handleCapture() {
         if (!captureText.trim()) return;
@@ -31,39 +42,56 @@
     }
 </script>
 
-<div class="flex flex-col gap-4 font-mono">
-    <h3 class="text-xs font-bold tracking-[0.2em] text-primary/80 border-b border-primary/30 pb-2 flex items-center gap-2">
-        <span class="material-symbols-outlined text-[16px]">edit_note</span>
-        QUICK CAPTURE
-    </h3>
+<svelte:window on:keydown={handleKeydown} />
 
-    <form on:submit|preventDefault={handleCapture} class="flex flex-col gap-3">
-        <textarea
-            bind:value={captureText}
-            placeholder="Type a thought, task, or realization... (Alt+C)"
-            disabled={isSubmitting}
-            class="w-full h-24 bg-black/50 border border-primary/30 p-3 text-xs text-primary focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all resize-none placeholder:text-primary/30"
-        ></textarea>
+<!-- Floating trigger button -->
+<button
+    class="fixed bottom-6 right-6 z-50 w-12 h-12 bg-primary/20 border border-primary text-primary hover:bg-primary hover:text-black transition-all font-mono text-lg flex items-center justify-center shadow-lg shadow-black/50 {isOpen ? 'rotate-45' : ''}"
+    on:click={() => isOpen = !isOpen}
+    title="Quick Capture (Alt+C)"
+>
+    <span class="material-symbols-outlined text-[20px]">{isOpen ? 'close' : 'edit_note'}</span>
+</button>
 
-        <button
-            class="w-full bg-primary/10 border border-primary text-primary text-xs font-bold tracking-widest py-2 hover:bg-primary hover:text-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            type="submit"
-            disabled={isSubmitting || !captureText.trim()}
-        >
-            {#if isSubmitting}
-                <span class="animate-pulse">CAPTURING...</span>
-            {:else}
-                CAPTURE NOTE
+<!-- Floating capture panel -->
+{#if isOpen}
+    <div class="fixed bottom-20 right-6 z-50 w-80 bg-black border border-primary shadow-xl shadow-black/80 font-mono">
+        <div class="p-4 flex flex-col gap-3">
+            <h3 class="text-xs font-bold tracking-[0.2em] text-primary/80 flex items-center gap-2">
+                <span class="material-symbols-outlined text-[16px]">edit_note</span>
+                QUICK CAPTURE
+                <span class="text-[10px] text-primary/30 ml-auto">Alt+C</span>
+            </h3>
+
+            <form on:submit|preventDefault={handleCapture} class="flex flex-col gap-3">
+                <textarea
+                    bind:value={captureText}
+                    placeholder="Type a thought, task, or realization..."
+                    disabled={isSubmitting}
+                    class="w-full h-24 bg-black/50 border border-primary/30 p-3 text-xs text-primary focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all resize-none placeholder:text-primary/30"
+                ></textarea>
+
+                <button
+                    class="w-full bg-primary/10 border border-primary text-primary text-xs font-bold tracking-widest py-2 hover:bg-primary hover:text-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    type="submit"
+                    disabled={isSubmitting || !captureText.trim()}
+                >
+                    {#if isSubmitting}
+                        <span class="animate-pulse">CAPTURING...</span>
+                    {:else}
+                        CAPTURE NOTE
+                    {/if}
+                </button>
+            </form>
+
+            {#if lastCreatedId}
+                <p class="text-[10px] font-mono text-primary/60">
+                    CAPTURED: <span class="text-primary">{lastCreatedId}</span>
+                </p>
             {/if}
-        </button>
-    </form>
-
-    {#if lastCreatedId}
-        <p class="text-[10px] font-mono text-primary/60">
-            CAPTURED: <span class="text-primary">{lastCreatedId}</span>
-        </p>
-    {/if}
-    {#if errorMsg}
-        <p class="text-[10px] font-mono text-destructive">{errorMsg}</p>
-    {/if}
-</div>
+            {#if errorMsg}
+                <p class="text-[10px] font-mono text-destructive">{errorMsg}</p>
+            {/if}
+        </div>
+    </div>
+{/if}

--- a/overwhelm-dashboard/src/lib/components/dashboard/SynthesisPanel.svelte
+++ b/overwhelm-dashboard/src/lib/components/dashboard/SynthesisPanel.svelte
@@ -1,29 +1,37 @@
 <script lang="ts">
     export let synthesis: any;
     export let dailyStory: any;
-    /** When true, show only the daily story (for above-the-fold placement).
+    /** When true, show daily story + inline insight badges.
      *  When false, show alignment/blockers/context cards (for sidebar). */
     export let inline: boolean = false;
 
     $: hasSynthesis = synthesis && Object.keys(synthesis).length > 0;
     $: rawStoryParagraphs = dailyStory?.story || synthesis?.daily_narrative || synthesis?.narrative || [];
-    $: storyParagraphs = rawStoryParagraphs.reduce((acc: any[], curr: any) => {
-        const existing = acc.find((item: any) => item.text === curr);
-        if (existing) {
-            existing.count++;
-        } else {
-            acc.push({ text: curr, count: 1 });
+
+    // Group story entries by project prefix and deduplicate
+    $: storyByProject = (() => {
+        const groups: Map<string, string[]> = new Map();
+        const seen = new Set<string>();
+        for (const raw of rawStoryParagraphs) {
+            const text = typeof raw === 'string' ? raw : String(raw);
+            const match = text.match(/^\[([^\]]+)\]\s*(.+)$/);
+            const project = match ? match[1] : '_general';
+            const content = match ? match[2] : text;
+            if (seen.has(content)) continue;
+            seen.add(content);
+            if (!groups.has(project)) groups.set(project, []);
+            groups.get(project)!.push(content);
         }
-        return acc;
-    }, []).map((item: any) => item.count > 1 ? `[${item.count}x] ${item.text}` : item.text);
-    $: hasStory = storyParagraphs && storyParagraphs.length > 0;
+        return groups;
+    })();
+
+    $: hasStory = storyByProject.size > 0;
     $: ageMinutes = synthesis?._age_minutes;
     $: isStale = ageMinutes !== undefined && ageMinutes > 120;
 </script>
 
 {#if inline}
-    <!-- Above-the-fold: daily story only -->
-    <div class="flex flex-col gap-2 font-mono">
+    <div class="flex flex-col gap-3 font-mono">
         <div class="flex justify-between items-baseline">
             <h3 class="text-xs font-bold tracking-[0.2em] text-primary/80">TODAY'S STORY</h3>
             <div class="flex items-center gap-2">
@@ -39,14 +47,61 @@
         </div>
 
         {#if hasStory}
-            <div class="text-sm text-primary/80 space-y-2 leading-relaxed">
-                {#each storyParagraphs as paragraph}
-                    <p>{paragraph}</p>
+            <div class="flex flex-col gap-3">
+                {#each [...storyByProject.entries()] as [project, items]}
+                    {#if project === '_general'}
+                        <div class="text-sm text-primary/80 space-y-1 leading-relaxed">
+                            {#each items as item}
+                                <p>{item}</p>
+                            {/each}
+                        </div>
+                    {:else}
+                        <div class="flex flex-col gap-1">
+                            <span class="text-[10px] font-bold bg-primary/15 text-primary/70 px-1.5 py-0.5 w-fit">{project}</span>
+                            <ul class="text-sm text-primary/80 space-y-0.5 ml-3">
+                                {#each items as item}
+                                    <li class="before:content-['›_'] before:text-primary/30">{item}</li>
+                                {/each}
+                            </ul>
+                        </div>
+                    {/if}
                 {/each}
             </div>
         {:else}
             <div class="text-sm text-primary/40 italic">
                 No narrative available. Run <code class="text-primary/60">/daily</code> to generate today's story.
+            </div>
+        {/if}
+
+        <!-- Inline insight badges -->
+        {#if hasSynthesis}
+            <div class="flex flex-wrap gap-3 mt-1">
+                {#if synthesis.alignment}
+                    {@const align = synthesis.alignment}
+                    {@const alignStatus = typeof align === 'string' ? align : (align.status || align.assessment || 'unknown')}
+                    <div class="flex items-center gap-2">
+                        <span class="text-[10px] text-primary/50">ALIGNMENT:</span>
+                        <span class="text-[10px] font-bold px-1.5 py-0.5 border {alignStatus === 'on_track' ? 'bg-green-900/30 text-green-400 border-green-500/40' : alignStatus === 'drifting' ? 'bg-yellow-900/30 text-yellow-400 border-yellow-500/40' : 'bg-primary/10 text-primary/70 border-primary/30'}">
+                            {alignStatus.toUpperCase().replace('_', ' ')}
+                        </span>
+                    </div>
+                {/if}
+
+                {#if synthesis.blockers}
+                    <div class="flex items-center gap-2">
+                        <span class="text-[10px] text-red-500/70">BLOCKERS:</span>
+                        <span class="text-[10px] text-red-400">
+                            {Array.isArray(synthesis.blockers) ? synthesis.blockers.length : 1}
+                        </span>
+                    </div>
+                {/if}
+
+                {#if synthesis.recent_context}
+                    <div class="flex items-center gap-2">
+                        <span class="text-[10px] text-primary/50">CONTEXT:</span>
+                        <span class="text-[10px] text-primary/60 truncate max-w-[300px]">{synthesis.recent_context}</span>
+                    </div>
+                {/if}
             </div>
         {/if}
     </div>

--- a/overwhelm-dashboard/src/routes/+page.server.ts
+++ b/overwhelm-dashboard/src/routes/+page.server.ts
@@ -150,92 +150,75 @@ async function loadRecentSummaries(days = 3): Promise<any[]> {
 }
 
 function buildPathData(summaries: any[]): any {
-    // Group summaries by project into threads
-    const byProject = new Map<string, any[]>();
+    const abandoned: any[] = [];
+    const now = new Date();
+    const todayStr = now.toISOString().slice(0, 10);
+    const yesterday = new Date(now.getTime() - 86400000);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+    // Collect accomplishments per project, deduped
+    const byProject = new Map<string, { items: any[]; latestDate: string }>();
+    const seenAccomplishments = new Set<string>();
+
     for (const s of summaries) {
         const proj = s.project || 'unknown';
-        if (!byProject.has(proj)) byProject.set(proj, []);
-        byProject.get(proj)!.push(s);
-    }
+        if (!byProject.has(proj)) byProject.set(proj, { items: [], latestDate: '' });
+        const group = byProject.get(proj)!;
 
-    const threads: any[] = [];
-    const abandoned: any[] = [];
+        const sessionDate = s.date || '';
+        const dateStr = sessionDate.slice(0, 10);
+        if (dateStr > group.latestDate) group.latestDate = dateStr;
 
-    for (const [project, sessions] of byProject) {
-        for (const s of sessions) {
-            const events: any[] = [];
+        const outcome = s.outcome || 'unknown';
 
-            // Build events from timeline_events if available
-            for (const te of s.timeline_events || []) {
-                if (te.type === 'user_prompt') {
-                    // Trim hook context noise from descriptions
-                    let desc = te.description || '';
-                    const hookIdx = desc.indexOf('<hook_context>');
-                    if (hookIdx > 0) desc = desc.slice(0, hookIdx).trim();
-                    if (desc.length > 200) desc = desc.slice(0, 200) + '…';
-                    if (desc && desc !== 'Request cancelled.') {
-                        events.push({
-                            timestamp: te.timestamp,
-                            narrative: desc,
-                        });
-                    }
-                }
+        // Use accomplishments as the primary source — meaningful outcomes, not raw events
+        const accomplishments = s.accomplishments || [];
+        if (accomplishments.length > 0) {
+            for (const acc of accomplishments) {
+                const key = `${proj}:${acc}`;
+                if (seenAccomplishments.has(key)) continue;
+                seenAccomplishments.add(key);
+                group.items.push({ text: acc, outcome, date: dateStr });
             }
-
-            // Fall back to accomplishments as events if no timeline
-            if (events.length === 0) {
-                for (const acc of s.accomplishments || []) {
-                    events.push({
-                        timestamp: s.date,
-                        narrative: acc,
-                    });
-                }
+        } else if (s.summary) {
+            const key = `${proj}:${s.summary}`;
+            if (!seenAccomplishments.has(key)) {
+                seenAccomplishments.add(key);
+                group.items.push({ text: s.summary, outcome, date: dateStr });
             }
+        }
 
-            // If still no events, use summary
-            if (events.length === 0 && s.summary) {
-                events.push({
-                    timestamp: s.date,
-                    narrative: s.summary,
+        // Detect abandoned work: sessions with friction or no outcome
+        if (outcome !== 'success' && s.friction_points?.length > 0) {
+            for (const fp of s.friction_points) {
+                const sessionDateObj = sessionDate ? new Date(sessionDate) : null;
+                const minutesAgo = sessionDateObj ? (Date.now() - sessionDateObj.getTime()) / 60000 : 0;
+                abandoned.push({
+                    project: proj,
+                    description: fp,
+                    time_ago: minutesAgo < 60
+                        ? `${Math.round(minutesAgo)}m ago`
+                        : minutesAgo < 1440
+                            ? `${Math.round(minutesAgo / 60)}h ago`
+                            : `${Math.round(minutesAgo / 1440)}d ago`,
                 });
-            }
-
-            if (events.length > 0) {
-                threads.push({
-                    project,
-                    session_id: s.session_id || '',
-                    initial_goal: s.summary || '',
-                    events,
-                });
-            }
-
-            // Detect abandoned work: sessions with friction or no outcome
-            if (s.outcome !== 'success' && s.friction_points?.length > 0) {
-                for (const fp of s.friction_points) {
-                    const sessionDate = s.date ? new Date(s.date) : null;
-                    const minutesAgo = sessionDate ? (Date.now() - sessionDate.getTime()) / 60000 : 0;
-                    abandoned.push({
-                        project,
-                        description: fp,
-                        time_ago: minutesAgo < 60
-                            ? `${Math.round(minutesAgo)}m ago`
-                            : minutesAgo < 1440
-                                ? `${Math.round(minutesAgo / 60)}h ago`
-                                : `${Math.round(minutesAgo / 1440)}d ago`,
-                    });
-                }
             }
         }
     }
 
-    // Sort threads by most recent event
-    threads.sort((a, b) => {
-        const aTime = a.events[a.events.length - 1]?.timestamp || '';
-        const bTime = b.events[b.events.length - 1]?.timestamp || '';
-        return bTime.localeCompare(aTime);
-    });
+    // Build activity feed sorted by most recent activity
+    const activity = Array.from(byProject.entries())
+        .map(([project, { items, latestDate }]) => {
+            let period: string;
+            if (latestDate === todayStr) period = 'today';
+            else if (latestDate === yesterdayStr) period = 'yesterday';
+            else period = `${Math.ceil((now.getTime() - new Date(latestDate).getTime()) / 86400000)}d ago`;
+            return { project, period, latestDate, items };
+        })
+        .filter(g => g.items.length > 0)
+        .sort((a, b) => b.latestDate.localeCompare(a.latestDate));
 
-    return { threads, abandoned_work: abandoned };
+    return { activity, abandoned_work: abandoned };
 }
 
 function formatProjectName(folder: string): string {


### PR DESCRIPTION
## Summary

Comprehensive QA-driven improvements to the overwhelm dashboard landing page, addressing usability issues that prevented the dashboard from serving its core purpose of reducing cognitive load for ADHD context recovery.

### Changes

- **Activity feed redesign** — replaced the raw session timeline (22k+ pixels of events) with a compact project-grouped accomplishments feed. Shows outcome icons (✓/↻/✗), groups by project, limits to 8 projects with "show more". Cuts the section from 22k to ~200px.
- **Dropped threads promoted** — abandoned work section moved to standalone bordered section with yellow accent, no longer buried in timeline.
- **Grid layout fix** — removed `flex-1 min-h-0` that caused zero-height grid collapse, making Recent Sessions and Project Dashboard unreachable.
- **Floating Quick Capture** — moved from buried sidebar to fixed-position overlay (bottom-right, Alt+C toggle) for always-accessible thought capture.
- **Today's Story formatting** — raw `[project] Successfully completed: X` entries now grouped by project with bullet formatting and deduplication.
- **Friendlier empty state** — "All quiet" with moon icon replaces clinical "No active agent sessions" message.
- **Responsive grid** — `lg:` breakpoint so grid stacks on mobile/tablet.

### Architecture

- `+page.server.ts`: `buildPathData()` rewritten to extract accomplishments (not raw events) per project, with deduplication
- `PathTimeline.svelte`: complete rewrite as activity feed component
- `DashboardView.svelte`: layout restructured with proper section hierarchy
- `QuickCapture.svelte`: rewritten as floating overlay
- `SynthesisPanel.svelte`: story grouping by project prefix

## Test plan

- [ ] Activity feed shows project-grouped accomplishments with outcome icons
- [ ] "Show N more projects" button appears when >8 project groups exist
- [ ] Dropped threads section renders with yellow border when abandoned work exists
- [ ] Today's Story groups entries by project with bullet formatting
- [ ] Quick Capture floating button visible at bottom-right, Alt+C opens/closes
- [ ] Empty Active Sessions shows "All quiet" with moon icon
- [ ] Scroll to bottom — Recent Sessions and Project Dashboard are reachable
- [ ] Resize to mobile width — grid stacks to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)