### PR TITLE
chore(dashboard): address PR 158 review comments

### DIFF
--- a/overwhelm-dashboard/src/lib/components/dashboard/ProjectDashboard.svelte
+++ b/overwhelm-dashboard/src/lib/components/dashboard/ProjectDashboard.svelte
@@ -52,7 +52,6 @@
             {@const members = projectMembers.get(project) || [project]}
             {@const meta = members.reduce((acc, p) => ({ ...acc, ...(projectData.meta?.[p] || {}) }), {} as any)}
             {@const allEpics = members.flatMap(p => (projectData.meta?.[p] || {}).epics || [])}
-            {@const _meta = allEpics.length > 0 ? { ...meta, epics: allEpics } : meta}
             {@const storeTasks = $graphData ? $graphData.nodes.filter(n => n.type === 'task' && members.includes(n.project || '') && ['active', 'in_progress', 'blocked'].includes(n.status)) : []}
             {@const tasks = storeTasks.length > 0 ? storeTasks : members.flatMap(p => projectData.tasks?.[p] || [])}
             {@const accomplishments = members.flatMap(p => projectData.accomplishments?.[p] || [])}
@@ -77,9 +76,9 @@
                     </div>
 
                     <div class="flex flex-col gap-4">
-                        {#if _meta.epics && _meta.epics.length > 0}
+                        {#if allEpics.length > 0}
                             <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-                                {#each _meta.epics as epic}
+                                {#each allEpics as epic}
                                     <div class="bg-black/40 border border-primary/20 p-3 hover:border-primary transition-colors cursor-pointer"
                                          role="button" tabindex="0"
                                          on:click={() => { const eNode = $graphData?.nodes.find(n => n.label === epic.title && n.type === 'epic'); if (eNode) toggleSelection(eNode.id); }}

--- a/overwhelm-dashboard/src/lib/components/shared/NodeShapes.ts
+++ b/overwhelm-dashboard/src/lib/components/shared/NodeShapes.ts
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 import type { GraphNode } from '../../data/prepareGraphData';
+import { projectHue } from '../../data/projectUtils';
 
 function escapeHtml(str: string): string {
     return str
@@ -143,16 +144,6 @@ export function treemapHeaderMetrics(w: number, h: number, label: string, depth:
     const basePad = 8;
     const headerH = Math.max(14, Math.min(50, lines * lineHeight + basePad));
     return { headerH, fs, lines, badgeReserve, pad };
-}
-
-export function projectHue(projectId: string): number {
-    let hash = 0;
-    const id = projectId || 'default';
-    for (let i = 0; i < id.length; i++) {
-        hash = (hash << 5) - hash + id.charCodeAt(i);
-        hash |= 0;
-    }
-    return Math.abs(hash) % 360;
 }
 
 /** Render a child-count badge in top-right of a container: visible/total leaf descendants */

--- a/overwhelm-dashboard/src/lib/components/views/ForceView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/ForceView.svelte
@@ -6,7 +6,8 @@
     import { viewSettings } from "../../stores/viewSettings";
     import { filters, type EdgeVisibility } from "../../stores/filters";
     import { selection, toggleSelection } from "../../stores/selection";
-    import { buildTaskCardNode, projectHue } from "../shared/NodeShapes";
+    import { buildTaskCardNode } from "../shared/NodeShapes";
+    import { projectHue } from "../../data/projectUtils";
     import { routeSfdpEdges } from "../shared/EdgeRenderer";
     import { FORCE_CONFIG } from "../../data/constants";
     import type { GraphNode, GraphEdge } from "../../data/prepareGraphData";

--- a/overwhelm-dashboard/src/lib/components/views/MetroView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/MetroView.svelte
@@ -127,7 +127,6 @@
         cy = cytoscape({
             container: containerEl,
             elements,
-            ready: function() { (window as any).__cy = this; },
             style: [
                 // Container-type nodes (epics, projects, goals) — larger interchange stations
                 {

--- a/overwhelm-dashboard/src/lib/components/views/ThreadedTasksView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/ThreadedTasksView.svelte
@@ -3,7 +3,7 @@
     import { selection } from "../../stores/selection";
     import { filters } from "../../stores/filters";
     import { PRIORITIES } from "../../data/constants";
-    import { projectHue } from "../shared/NodeShapes";
+    import { projectHue } from "../../data/projectUtils";
     import TaskEditorView from "./TaskEditorView.svelte";
 
     let currentTab = "ACTIVE_TASKS";


### PR DESCRIPTION
Addresses review comments on PR 158:

- Removed unnecessary `_meta` constant in `ProjectDashboard.svelte` and replaced it directly with `allEpics` in the template to improve readability.
- Removed duplicate `projectHue` function from `NodeShapes.ts`.
- Imported `projectHue` from `projectUtils.ts` in `NodeShapes.ts`.
- Updated `projectHue` imports in `ThreadedTasksView.svelte` and `ForceView.svelte` to point to the `projectUtils.ts` implementation.
- Fixed an invalid TS type object literal parameter in `MetroView.svelte` during testing.

---
*PR created automatically by Jules for task [18379672258811113189](https://jules.google.com/task/18379672258811113189) started by @nicsuzor*