### PR TITLE
feat(mcp): switch get_document to ID-based lookup

### DIFF
--- a/overwhelm-dashboard/src/lib/components/shared/Legend.svelte
+++ b/overwhelm-dashboard/src/lib/components/shared/Legend.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { filters, cycleEdgeVisibility, type EdgeVisibility } from '../../stores/filters';
+    import { filters, cycleVisibility, type VisibilityState } from '../../stores/filters';
     import { graphData } from '../../stores/graph';
     import { PRIORITIES } from '../../data/constants';
     import { projectColor } from '../../data/projectUtils';
@@ -10,13 +10,14 @@
 
     // Status = fill color (muted defaults, saturated for attention)
     const statusGroups = [
-        { key: 'showActive', label: 'ACTIVE', statuses: ['active', 'inbox', 'todo', 'in_progress', 'review'], color: '#2C4A88' },
-        { key: 'showBlocked', label: 'BLOCKED', statuses: ['blocked'], color: '#6B3A3A' },
-        { key: 'showCompleted', label: 'COMPLETED', statuses: ['done', 'completed', 'cancelled'], color: '#1E1E24' },
+        { key: 'statusActive', label: 'ACTIVE', color: '#2C4A88' },
+        { key: 'statusBlocked', label: 'BLOCKED', color: '#6B3A3A' },
+        { key: 'statusCompleted', label: 'COMPLETED', color: '#1E1E24' },
     ] as const;
 
-    // Priority = border color — now interactive (click to filter)
+    // Priority = border color — now interactive (click to cycle)
     const priorityItems = PRIORITIES.map(p => ({
+        key: `priority${p.value}`,
         value: p.value,
         label: `P${p.value} ${p.label}`,
         color: p.color,
@@ -28,35 +29,35 @@
         { key: 'edgeReferences', label: 'REFERENCES', color: '#a3a3a3', dash: true },
     ] as const;
 
-    function toggleStatus(key: string) {
-        filters.update(f => ({ ...f, [key]: !f[key as keyof typeof f] }));
-    }
-
-    function togglePriority(value: number) {
-        filters.update(f => {
-            const current = f.priorityFilter;
-            return { ...f, priorityFilter: current === value ? null : value };
-        });
-    }
-
-    function setProjectFilter(project: string) {
-        filters.update(f => ({ ...f, project }));
-    }
-
-    function cycleEdge(key: string) {
+    function cycleFilter(key: string) {
         filters.update(f => ({
             ...f,
-            [key]: cycleEdgeVisibility(f[key as keyof typeof f] as EdgeVisibility),
+            [key]: cycleVisibility(f[key as keyof typeof f] as VisibilityState),
         }));
     }
 
-    function edgeOpacityForLegend(vis: EdgeVisibility): number {
+    function toggleProject(project: string) {
+        filters.update(f => {
+            const hidden = f.hiddenProjects || [];
+            if (hidden.includes(project)) {
+                return { ...f, hiddenProjects: hidden.filter(p => p !== project) };
+            } else {
+                return { ...f, hiddenProjects: [...hidden, project] };
+            }
+        });
+    }
+
+    function toggleAllProjects() {
+        filters.update(f => ({ ...f, hiddenProjects: [] }));
+    }
+
+    function edgeOpacityForLegend(vis: VisibilityState): number {
         if (vis === 'bright') return 1;
         if (vis === 'half') return 0.4;
         return 0.1;
     }
 
-    function edgeStateLabel(vis: EdgeVisibility): string {
+    function stateLabel(vis: VisibilityState): string {
         if (vis === 'bright') return '●';
         if (vis === 'half') return '◐';
         return '○';
@@ -83,36 +84,38 @@
             </button>
         </div>
 
-        <!-- Status filters -->
+        <!-- Status filters (click to cycle: bright → half → hidden) -->
         <div class="legend-section">
+            <span class="legend-section-title">STATUS</span>
             {#each statusGroups as group}
+                {@const vis = $filters[group.key as keyof typeof $filters] as VisibilityState}
                 <button
                     class="legend-item"
-                    class:dimmed={!$filters[group.key]}
-                    on:click={() => toggleStatus(group.key)}
+                    class:dimmed={vis === 'hidden'}
+                    on:click={() => cycleFilter(group.key)}
+                    title="Click to cycle: bright → half → hidden"
                 >
-                    <div class="legend-box" style="background:{group.color}; opacity:{$filters[group.key] ? 1 : 0.2}"></div>
+                    <div class="legend-box" style="background:{group.color}; opacity:{edgeOpacityForLegend(vis)};"></div>
                     <span class="legend-label">{group.label}</span>
+                    <span class="edge-state">{stateLabel(vis)}</span>
                 </button>
             {/each}
         </div>
 
-        <!-- Priority filter (click to isolate a priority level) -->
+        <!-- Priority filter (click to cycle: bright → half → hidden) -->
         <div class="legend-section">
-            <span class="legend-section-title">PRIORITY (CLICK TO FILTER)</span>
+            <span class="legend-section-title">PRIORITY</span>
             {#each priorityItems as p}
+                {@const vis = $filters[p.key as keyof typeof $filters] as VisibilityState}
                 <button
                     class="legend-item"
-                    class:active-filter={$filters.priorityFilter === p.value}
-                    class:dimmed={$filters.priorityFilter !== null && $filters.priorityFilter !== p.value}
-                    on:click={() => togglePriority(p.value)}
-                    title="Click to show only P{p.value} tasks"
+                    class:dimmed={vis === 'hidden'}
+                    on:click={() => cycleFilter(p.key)}
+                    title="Click to cycle: bright → half → hidden"
                 >
-                    <div class="legend-box" style="background:transparent; border: 2px solid {p.color};"></div>
+                    <div class="legend-box" style="background:transparent; border: 2px solid {p.color}; opacity:{edgeOpacityForLegend(vis)};"></div>
                     <span class="legend-label">{p.label}</span>
-                    {#if $filters.priorityFilter === p.value}
-                        <span class="filter-badge">ON</span>
-                    {/if}
+                    <span class="edge-state">{stateLabel(vis)}</span>
                 </button>
             {/each}
         </div>
@@ -121,32 +124,32 @@
         <div class="legend-section">
             <span class="legend-section-title">EDGES</span>
             {#each edgeTypes as edge}
-                {@const vis = $filters[edge.key]}
+                {@const vis = $filters[edge.key as keyof typeof $filters] as VisibilityState}
                 <button
                     class="legend-item"
                     class:dimmed={vis === 'hidden'}
-                    on:click={() => cycleEdge(edge.key)}
+                    on:click={() => cycleFilter(edge.key)}
                     title="Click to cycle: bright → half → hidden"
                 >
                     <div class="legend-line" style="background:{edge.color}; opacity:{edgeOpacityForLegend(vis)};"
                         class:dashed={edge.dash}></div>
                     <span class="legend-label">{edge.label}</span>
-                    <span class="edge-state">{edgeStateLabel(vis)}</span>
+                    <span class="edge-state">{stateLabel(vis)}</span>
                 </button>
             {/each}
         </div>
 
         <!-- Project filter with color swatches -->
         <div class="legend-section">
-            <span class="legend-section-title">PROJECTS</span>
+            <span class="legend-section-title">PROJECTS (CLICK TO TOGGLE)</span>
             <button
                 class="legend-item"
-                class:active-filter={$filters.project === 'ALL'}
-                on:click={() => setProjectFilter('ALL')}
+                class:dimmed={($filters.hiddenProjects?.length ?? 0) > 0}
+                on:click={toggleAllProjects}
             >
                 <div class="legend-box" style="background: #666; border-radius: 50%;"></div>
                 <span class="legend-label">ALL PROJECTS</span>
-                {#if $filters.project === 'ALL'}
+                {#if ($filters.hiddenProjects?.length ?? 0) === 0}
                     <span class="filter-badge">ON</span>
                 {/if}
             </button>
@@ -154,14 +157,13 @@
                 {#each visibleProjects as proj}
                     <button
                         class="legend-item"
-                        class:active-filter={$filters.project === proj}
-                        class:dimmed={$filters.project !== 'ALL' && $filters.project !== proj}
-                        on:click={() => setProjectFilter(proj)}
-                        title="Filter to {proj}"
+                        class:dimmed={$filters.hiddenProjects?.includes(proj)}
+                        on:click={() => toggleProject(proj)}
+                        title="Toggle {proj}"
                     >
                         <div class="legend-box project-swatch" style="background: {projectColor(proj)};"></div>
                         <span class="legend-label">{(proj || '').toUpperCase()}</span>
-                        {#if $filters.project === proj}
+                        {#if !($filters.hiddenProjects?.includes(proj))}
                             <span class="filter-badge">ON</span>
                         {/if}
                     </button>

--- a/overwhelm-dashboard/src/lib/components/shared/NodeShapes.ts
+++ b/overwhelm-dashboard/src/lib/components/shared/NodeShapes.ts
@@ -86,7 +86,7 @@ export function buildTaskCardNode(g: d3.Selection<SVGGElement, GraphNode, null, 
         const epicFill = `hsl(${hue}, 35%, 85%)`;
         const epicStroke = `hsl(${hue}, 45%, 45%)`;
 
-        const sw = d.w * EPIC_SCALE, sh = d.h * EPIC_SCALE;
+        const sw = d.w, sh = d.h;
         const shw = sw / 2, shh = sh / 2;
         const c = Math.min(shh * 0.5, EPIC_CORNER_RADIUS);
         const pts = `${-shw + c},${-shh} ${shw - c},${-shh} ${shw},${0} ${shw - c},${shh} ${-shw + c},${shh} ${-shw},${0}`;

--- a/overwhelm-dashboard/src/lib/components/shared/Toast.svelte
+++ b/overwhelm-dashboard/src/lib/components/shared/Toast.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+    import { toast } from '../../stores/toast';
+</script>
+
+{#if $toast.length > 0}
+    <div class="fixed top-4 left-1/2 -translate-x-1/2 z-[1000] flex flex-col items-center gap-2 pointer-events-none">
+        {#each $toast as t (t.id)}
+            <div 
+                class="px-4 py-2 rounded-md font-mono text-sm font-bold shadow-lg flex items-center gap-2 transition-all"
+                class:bg-emerald-900={t.type === 'success'}
+                class:text-emerald-100={t.type === 'success'}
+                class:border={true}
+                class:border-emerald-500={t.type === 'success'}
+                class:bg-red-900={t.type === 'error'}
+                class:text-red-100={t.type === 'error'}
+                class:border-red-500={t.type === 'error'}
+                class:bg-blue-900={t.type === 'info'}
+                class:text-blue-100={t.type === 'info'}
+                class:border-blue-500={t.type === 'info'}
+            >
+                <span class="material-symbols-outlined text-base">
+                    {#if t.type === 'success'}
+                        check_circle
+                    {:else if t.type === 'error'}
+                        error
+                    {:else}
+                        info
+                    {/if}
+                </span>
+                {t.message}
+            </div>
+        {/each}
+    </div>
+{/if}

--- a/overwhelm-dashboard/src/lib/components/views/CirclePackView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/CirclePackView.svelte
@@ -247,15 +247,16 @@
             }
         });
 
-        // Gentle dimming: non-focus leaves slightly faded
+        // Gentle dimming: non-focus leaves slightly faded, and filter-dimmed nodes heavily faded
         if (showFocus) {
             nEls.style("opacity", (d: any) => {
+                if (d.filter_dimmed) return 0.2;
                 if (!d._isLeaf) return null;
                 if (focusIds.has(d.id)) return 1;
                 return 0.6;
             });
         } else {
-            nEls.style("opacity", null);
+            nEls.style("opacity", (d: any) => d.filter_dimmed ? 0.2 : null);
         }
 
         const eEls = d3

--- a/overwhelm-dashboard/src/lib/components/views/ForceView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/ForceView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import * as d3 from "d3";
+    import * as cola from "webcola";
     import { onMount, onDestroy } from "svelte";
     import { graphData, graphStructureKey } from "../../stores/graph";
     import { viewSettings } from "../../stores/viewSettings";
@@ -20,8 +21,8 @@
     let edgesLayer: SVGGElement;
     let hullLayer: SVGGElement;
 
-    let simulation: d3.Simulation<d3.SimulationNodeDatum, undefined> | null = null;
-    let layoutGroups: any[] = [];
+    let colaLayout: (cola.Layout & cola.ID3StyleLayoutAdaptor) | null = null;
+    let colaGroups: any[] = [];
     // Container nodes that have a Cola group box — their hexagon is hidden (box replaces it)
     let containerGroupNodeIds = new Set<string>();
     // Track cleanup and frame loop
@@ -236,17 +237,16 @@
                     .on("drag", (e, d: any) => {
                         // Lazy init: only pin/wake Cola once actual movement occurs
                         if (!(d as any)._dragging) {
-                            if (simulation) simulation.alphaTarget(0.3).restart();
+                            cola.Layout.dragStart(d);
                             (d as any)._dragging = true;
                         }
-                        d.fx = e.x;
-                        d.fy = e.y;
+                        d.x = e.x;
+                        d.y = e.y;
+                        if (colaLayout) colaLayout.resume();
                     })
                     .on("end", (e, d: any) => {
                         if ((d as any)._dragging) {
-                            d.fx = null;
-                            d.fy = null;
-                            if (simulation) simulation.alphaTarget(0);
+                            d.fixed = 0;
                             (d as any)._dragging = false;
                         }
                     }),
@@ -254,66 +254,15 @@
     }
 
     function tickVisuals() {
-        if (!simulation) return;
-
-        // Compute group bounding boxes manually bottom-up
-        if (layoutGroups && layoutGroups.length > 0) {
-            const computed = new Set();
-            function getBounds(g: any) {
-                if (computed.has(g)) return g.bounds;
-                let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-                
-                (g.leaves || []).forEach((idx: number) => {
-                    const n = layoutNodes[idx];
-                    if (!n) return;
-                    const halfW = (n.w || 0) / 2;
-                    const halfH = (n.h || 0) / 2;
-                    const nx = n.x ?? 0;
-                    const ny = n.y ?? 0;
-                    if (nx - halfW < minX) minX = nx - halfW;
-                    if (ny - halfH < minY) minY = ny - halfH;
-                    if (nx + halfW > maxX) maxX = nx + halfW;
-                    if (ny + halfH > maxY) maxY = ny + halfH;
-                });
-                
-                (g.groups || []).forEach((child: any) => {
-                    const cb = getBounds(child);
-                    if (cb) {
-                        if (cb.x < minX) minX = cb.x;
-                        if (cb.y < minY) minY = cb.y;
-                        if (cb.X > maxX) maxX = cb.X;
-                        if (cb.Y > maxY) maxY = cb.Y;
-                    }
-                });
-
-                if (minX !== Infinity) {
-                    const pad = g.padding || 0;
-                    minX -= pad;
-                    minY -= pad;
-                    maxX += pad;
-                    maxY += pad;
-                    g.bounds = {
-                        x: minX, y: minY, X: maxX, Y: maxY,
-                        width: () => maxX - minX,
-                        height: () => maxY - minY
-                    };
-                } else {
-                    g.bounds = null;
-                }
-                computed.add(g);
-                return g.bounds;
-            }
-
-            layoutGroups.forEach((g: any) => getBounds(g));
-        }
+        if (!colaLayout) return;
 
         d3.select(nodesLayer)
             .selectAll<SVGGElement, GraphNode>("g.node")
             .attr("transform", (d) => `translate(${d.x ?? 0},${d.y ?? 0})`);
 
         // Update obstacle data for edge routing from group bounding boxes.
-        if (layoutGroups) {
-            const groups = layoutGroups.filter((g: any) => g.label && g.bounds);
+        if (colaLayout) {
+            const groups = (colaLayout.groups() || []).filter((g: any) => g.label && g.bounds);
             const obstacles = groups.map((g: any) => ({
                 x: g.bounds.x,
                 y: g.bounds.y,
@@ -338,7 +287,7 @@
         }
 
         // Render group bounding boxes
-        if (hullLayer && layoutGroups) {
+        if (hullLayer && colaLayout) {
             const allGroups: any[] = [];
             function extractGroups(gList: any[]) {
                 for (const g of gList) {
@@ -346,7 +295,7 @@
                     if (g.groups && g.groups.length > 0) extractGroups(g.groups);
                 }
             }
-            extractGroups(layoutGroups);
+            extractGroups(colaLayout.groups() || []);
             
             // Deduplicate by containerId or label
             const uniqueGroups = Array.from(new Map(allGroups.map(g => [g.containerId || g.label, g])).values());
@@ -470,7 +419,7 @@
         if (!$graphData) return;
 
         // Setup DOM elements
-        if (simulation) { simulation.stop(); simulation = null; }
+        if (colaLayout) { colaLayout.stop(); colaLayout = null; }
 
         const data = $graphData;
 
@@ -644,10 +593,10 @@
             }
         }
 
-        // Convert group indices to actual object references for layoutGroups
-        layoutGroups = d3Groups.map(g => ({ ...g, groups: [] })); // shadow copy
+        // Convert group indices to actual object references for colaGroups
+        colaGroups = d3Groups.map(g => ({ ...g, groups: [] })); // shadow copy
         d3Groups.forEach((g, i) => {
-            layoutGroups[i].groups = (g.groups as number[]).map(idx => layoutGroups[idx]);
+            colaGroups[i].groups = (g.groups as number[]).map(idx => colaGroups[idx]);
         });
 
         // Mark which container nodes have a group box — their node visual will be hidden
@@ -655,7 +604,7 @@
 
         // Put ungrouped nodes in a catch-all group
         if (ungroupedIndices.length > 0) {
-            layoutGroups.push({ leaves: ungroupedIndices, groups: [], padding: groupPadding, label: '' });
+            colaGroups.push({ leaves: ungroupedIndices, groups: [], padding: groupPadding, label: '' });
         }
 
         // Pre-compute node→group membership for edge routing (avoids per-tick allocation).
@@ -679,8 +628,8 @@
                 });
             }
             const nestedResolved = new Set<any>();
-            layoutGroups.forEach(g => (g.groups || []).forEach((c: any) => nestedResolved.add(c)));
-            layoutGroups.forEach(g => {
+            colaGroups.forEach(g => (g.groups || []).forEach((c: any) => nestedResolved.add(c)));
+            colaGroups.forEach(g => {
                 if (!nestedResolved.has(g) && g.label) buildGroupMembership(g, []);
             });
         }
@@ -713,7 +662,7 @@
 
         // Pre-compute nested-group set for hull rendering
         layoutNestedGroupSet = new Set<any>();
-        layoutGroups.forEach((g: any) => {
+        colaGroups.forEach((g: any) => {
             (g.groups as any[]).forEach((child: any) => {
                 layoutNestedGroupSet.add(child);
             });
@@ -757,7 +706,7 @@
             }
         }
 
-        const topGroups = layoutGroups.filter(g => !layoutNestedGroupSet.has(g));
+        const topGroups = colaGroups.filter(g => !layoutNestedGroupSet.has(g));
         // Arrange top-level groups in a horizontal row with wrapping
         const cols = Math.max(1, Math.ceil(Math.sqrt(topGroups.length * (cw / ch))));
         const rows = Math.ceil(topGroups.length / cols);
@@ -822,41 +771,47 @@
         routeSfdpEdges(eEls);
         updateHulls();
 
-        // --- Phase 3: Start D3 layout ---
-        const d3Links = activeLinks.map((l: any) => {
-            const sid = typeof l.source === 'object' ? l.source.id : l.source;
-            const tid = typeof l.target === 'object' ? l.target.id : l.target;
-            if (!sid || !tid) return null;
+        // --- Phase 3: Start Cola layout ---
+        // By relying purely on WebCola's group bounding boxes to keep nodes together, 
+        // we prevent children from being pulled into a tight overlapping cluster at the center,
+        // allowing them to remain in their wide 2D grid seed layout without vertical stacking.
+        const colaLinks = activeLinks.map((l: any) => {
+            if (l.type === 'parent') return null; // Omit parent links from physics!
+
+            const si = nodeIndex.get(typeof l.source === 'object' ? l.source.id : l.source);
+            const ti = nodeIndex.get(typeof l.target === 'object' ? l.target.id : l.target);
+            if (si === undefined || ti === undefined) return null;
             
             let length = $viewSettings.colaLinkLength || 35;
-            let strength = 1.0;
+            let weight = 1.0;
             
-            if (l.type === 'parent') {
-                length = length * 0.8;
-                strength = 2.0; 
-            } else if (l.type === 'depends_on') {
-                length = length * 1.2; 
-                strength = 0.5;
+            if (l.type === 'depends_on') {
+                length = length * 1.2; // Flow dependencies slightly looser, but not harsh
+                weight = 1.0;
             } else {
-                length = length * 1.4; 
-                strength = 0.2; 
+                length = length * 1.4; // References looser, but evens out the forces
+                weight = 0.5; // Weakest weight
             }
-            return { source: sid, target: tid, length, strength, type: l.type };
+            return { source: si, target: ti, length, weight };
         }).filter((l: any) => l !== null) as any[];
 
-        const nestedCount = layoutGroups.filter(g => (g.groups || []).length > 0).length;
-        console.log(`[D3 Force] ${activeNodes.length} nodes, ${d3Links.length} links, ${layoutGroups.length} groups (${nestedCount} with children)`);
+        const nestedCount = colaGroups.filter(g => (g.groups || []).length > 0).length;
+        console.log(`[Cola] ${activeNodes.length} nodes, ${colaLinks.length} links, ${colaGroups.length} groups (${nestedCount} with children)`, colaGroups.map(g => `${g.leaves.length}L${(g.groups||[]).length ? '+' + (g.groups||[]).length + 'G' : ''}`));
 
-        simulation = d3.forceSimulation(activeNodes as any)
-            .force("link", d3.forceLink(d3Links).id((d: any) => d.id).distance((d: any) => d.length).strength((d: any) => d.strength))
-            .force("charge", d3.forceManyBody().strength(-300))
-            .force("center", d3.forceCenter(cw / 2, ch / 2))
-            .force("collide", d3.forceCollide().radius((d: any) => Math.max(d.w || 0, d.h || 0) / 2 + 10))
-            .on("tick", tickVisuals);
+        colaLayout = cola.d3adaptor(d3)
+            .size([cw, ch])
+            .nodes(activeNodes as any)
+            .links(colaLinks)
+            .groups(colaGroups)
+            .avoidOverlaps(true)
+            .handleDisconnected(true)
+            .linkDistance((d: any) => d.length)
+            .on("tick", tickVisuals)
+            .start(100, 100, 200);
     }
 
     onDestroy(() => {
-        if (simulation) simulation.stop();
+        if (colaLayout) colaLayout.stop();
         cancelAnimationFrame(frameId);
     });
 </script>

--- a/overwhelm-dashboard/src/lib/components/views/ForceView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/ForceView.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
     import * as d3 from "d3";
-    import * as cola from "webcola";
     import { onMount, onDestroy } from "svelte";
     import { graphData, graphStructureKey } from "../../stores/graph";
     import { viewSettings } from "../../stores/viewSettings";
-    import { filters, type EdgeVisibility } from "../../stores/filters";
+    import { filters, type VisibilityState } from "../../stores/filters";
     import { selection, toggleSelection } from "../../stores/selection";
     import { buildTaskCardNode } from "../shared/NodeShapes";
     import { projectHue } from "../../data/projectUtils";
@@ -21,7 +20,8 @@
     let edgesLayer: SVGGElement;
     let hullLayer: SVGGElement;
 
-    let colaLayout: (cola.Layout & cola.ID3StyleLayoutAdaptor) | null = null;
+    let simulation: d3.Simulation<d3.SimulationNodeDatum, undefined> | null = null;
+    let layoutGroups: any[] = [];
     // Container nodes that have a Cola group box — their hexagon is hidden (box replaces it)
     let containerGroupNodeIds = new Set<string>();
     // Track cleanup and frame loop
@@ -155,7 +155,7 @@
             const adj = adjacencyMap.get(hoveredId);
             if (adj) adj.forEach(id => neighbors.add(id));
 
-            nEls.classed("dimmed", (d: any) => !neighbors.has(d.id) && !selectedNeighbors.has(d.id))
+            nEls.classed("dimmed", (d: any) => (!neighbors.has(d.id) && !selectedNeighbors.has(d.id)) || d.filter_dimmed)
                 .classed("illuminated", (d: any) => neighbors.has(d.id) || selectedNeighbors.has(d.id));
 
             eEls.classed("dimmed", (l: any) => {
@@ -175,18 +175,18 @@
                 return hoverMatch || selMatch || activeMatch;
             });
         } else {
-            nEls.classed("dimmed", false).classed("illuminated", false);
+            nEls.classed("dimmed", (d: any) => d.filter_dimmed).classed("illuminated", false);
             eEls.classed("dimmed", false).classed("illuminated", false);
         }
     }
 
-    function edgeVisForType(type: string): EdgeVisibility {
+    function edgeVisForType(type: string): VisibilityState {
         if (type === 'parent') return $filters.edgeParent;
         if (type === 'depends_on') return $filters.edgeDependencies;
         return $filters.edgeReferences; // ref, soft_depends_on, etc.
     }
 
-    function edgeOpacity(vis: EdgeVisibility): number {
+    function edgeOpacity(vis: VisibilityState): number {
         if (vis === 'bright') return 0.85;
         if (vis === 'half') return 0.25;
         return 0;
@@ -236,16 +236,17 @@
                     .on("drag", (e, d: any) => {
                         // Lazy init: only pin/wake Cola once actual movement occurs
                         if (!(d as any)._dragging) {
-                            cola.Layout.dragStart(d);
+                            if (simulation) simulation.alphaTarget(0.3).restart();
                             (d as any)._dragging = true;
                         }
-                        d.x = e.x;
-                        d.y = e.y;
-                        if (colaLayout) colaLayout.resume();
+                        d.fx = e.x;
+                        d.fy = e.y;
                     })
                     .on("end", (e, d: any) => {
                         if ((d as any)._dragging) {
-                            d.fixed = 0;
+                            d.fx = null;
+                            d.fy = null;
+                            if (simulation) simulation.alphaTarget(0);
                             (d as any)._dragging = false;
                         }
                     }),
@@ -253,55 +254,66 @@
     }
 
     function tickVisuals() {
-        // --- Custom Force: Keep epics and child tasks closely packed ---
-        if ($graphData && parentOf) {
-            layoutNodes.forEach((n: any) => {
-                if (CONTAINER_TYPES.has(n.type)) return;
+        if (!simulation) return;
 
-                let cur = n.id;
-                let targetContainer = null;
-                for (let i = 0; i < 20; i++) {
-                    const pid = parentOf.get(cur);
-                    if (!pid) break;
-                    const pNode = layoutNodeMap.get(pid);
-                    if (pNode && CONTAINER_TYPES.has(pNode.type)) {
-                        targetContainer = pNode;
-                        break;
+        // Compute group bounding boxes manually bottom-up
+        if (layoutGroups && layoutGroups.length > 0) {
+            const computed = new Set();
+            function getBounds(g: any) {
+                if (computed.has(g)) return g.bounds;
+                let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+                
+                (g.leaves || []).forEach((idx: number) => {
+                    const n = layoutNodes[idx];
+                    if (!n) return;
+                    const halfW = (n.w || 0) / 2;
+                    const halfH = (n.h || 0) / 2;
+                    const nx = n.x ?? 0;
+                    const ny = n.y ?? 0;
+                    if (nx - halfW < minX) minX = nx - halfW;
+                    if (ny - halfH < minY) minY = ny - halfH;
+                    if (nx + halfW > maxX) maxX = nx + halfW;
+                    if (ny + halfH > maxY) maxY = ny + halfH;
+                });
+                
+                (g.groups || []).forEach((child: any) => {
+                    const cb = getBounds(child);
+                    if (cb) {
+                        if (cb.x < minX) minX = cb.x;
+                        if (cb.y < minY) minY = cb.y;
+                        if (cb.X > maxX) maxX = cb.X;
+                        if (cb.Y > maxY) maxY = cb.Y;
                     }
-                    cur = pid;
-                }
+                });
 
-                if (targetContainer && typeof targetContainer.x === 'number' && typeof targetContainer.y === 'number') {
-                    const dx = targetContainer.x - n.x;
-                    const dy = targetContainer.y - n.y;
-                    // Apply a strong attractive spring force towards the container centre
-                    n.x += dx * 0.25;
-                    n.y += dy * 0.25;
+                if (minX !== Infinity) {
+                    const pad = g.padding || 0;
+                    minX -= pad;
+                    minY -= pad;
+                    maxX += pad;
+                    maxY += pad;
+                    g.bounds = {
+                        x: minX, y: minY, X: maxX, Y: maxY,
+                        width: () => maxX - minX,
+                        height: () => maxY - minY
+                    };
+                } else {
+                    g.bounds = null;
                 }
-            });
-        }
+                computed.add(g);
+                return g.bounds;
+            }
 
-        // Anchor epic nodes to the center of their group bounding box
-        if (colaLayout) {
-            const groups = colaLayout.groups() || [];
-            groups.forEach((g: any) => {
-                if (!g.containerId || !g.bounds) return;
-                const epicNode = layoutNodeMap.get(g.containerId);
-                if (epicNode) {
-                    epicNode.x = (g.bounds.x + g.bounds.X) / 2;
-                    epicNode.y = (g.bounds.y + g.bounds.Y) / 2;
-                }
-            });
+            layoutGroups.forEach((g: any) => getBounds(g));
         }
 
         d3.select(nodesLayer)
             .selectAll<SVGGElement, GraphNode>("g.node")
             .attr("transform", (d) => `translate(${d.x ?? 0},${d.y ?? 0})`);
 
-        // Update obstacle data for edge routing from Cola group bounding boxes.
-        // Node→group membership is pre-computed in drawForceAndStartPhysics (layoutNodeGroupSets).
-        if (colaLayout) {
-            const groups = (colaLayout.groups() || []).filter((g: any) => g.label && g.bounds);
+        // Update obstacle data for edge routing from group bounding boxes.
+        if (layoutGroups) {
+            const groups = layoutGroups.filter((g: any) => g.label && g.bounds);
             const obstacles = groups.map((g: any) => ({
                 x: g.bounds.x,
                 y: g.bounds.y,
@@ -317,7 +329,6 @@
         applyEdgeVisibility(eEls);
 
         // P0/P1 edge glow: highlight edges along ancestor/descendant paths of high-priority nodes.
-        // layoutHighPriRelatedIds is pre-computed in drawForceAndStartPhysics — stable per layout.
         if (layoutHighPriRelatedIds.size > 0) {
             eEls.classed("high-priority-edge", (l: any) => {
                 const sid = l.source?.id || l.source;
@@ -326,12 +337,25 @@
             });
         }
 
-        // Render group bounding boxes from WebCola (skip unlabelled catch-all group)
-        if (hullLayer && colaLayout) {
-            const groups = (colaLayout.groups() || []).filter((g: any) => g.label);
+        // Render group bounding boxes
+        if (hullLayer && layoutGroups) {
+            const allGroups: any[] = [];
+            function extractGroups(gList: any[]) {
+                for (const g of gList) {
+                    if (g.label) allGroups.push(g);
+                    if (g.groups && g.groups.length > 0) extractGroups(g.groups);
+                }
+            }
+            extractGroups(layoutGroups);
+            
+            // Deduplicate by containerId or label
+            const uniqueGroups = Array.from(new Map(allGroups.map(g => [g.containerId || g.label, g])).values());
+            
+            const TOP_PAD = 60; // Extra visual padding extending upwards for titles
+
             const groupEls = d3.select(hullLayer)
                 .selectAll<SVGRectElement, any>("rect.cola-group")
-                .data(groups);
+                .data(uniqueGroups, (d: any) => d.containerId || d.label);
 
             // layoutNestedGroupSet is pre-computed in drawForceAndStartPhysics — stable per layout.
             groupEls.join("rect")
@@ -339,9 +363,9 @@
                 .attr("rx", (d: any) => layoutNestedGroupSet.has(d) ? 6 : 10)
                 .attr("ry", (d: any) => layoutNestedGroupSet.has(d) ? 6 : 10)
                 .attr("x", (d: any) => d.bounds?.x ?? 0)
-                .attr("y", (d: any) => d.bounds?.y ?? 0)
+                .attr("y", (d: any) => (d.bounds?.y ?? 0) - TOP_PAD)
                 .attr("width", (d: any) => d.bounds?.width() ?? 0)
-                .attr("height", (d: any) => d.bounds?.height() ?? 0)
+                .attr("height", (d: any) => (d.bounds?.height() ?? 0) + TOP_PAD)
                 .attr("fill", (d: any) => {
                     const hue = projectHue(d.containerId || d.label || '');
                     return layoutNestedGroupSet.has(d)
@@ -368,10 +392,30 @@
                     selection.update(s => ({ ...s, hoveredNodeId: null }));
                 });
 
+            // Header shading rect
+            const headerEls = d3.select(hullLayer)
+                .selectAll<SVGRectElement, any>("rect.cola-group-header")
+                .data(uniqueGroups, (d: any) => d.containerId || d.label);
+
+            headerEls.join("rect")
+                .attr("class", "cola-group-header")
+                .style("pointer-events", "none")
+                .attr("rx", (d: any) => layoutNestedGroupSet.has(d) ? 6 : 10)
+                .attr("ry", (d: any) => layoutNestedGroupSet.has(d) ? 6 : 10)
+                // Draw a rectangle covering just the top section of the group
+                .attr("x", (d: any) => d.bounds?.x ?? 0)
+                .attr("y", (d: any) => (d.bounds?.y ?? 0) - TOP_PAD)
+                .attr("width", (d: any) => d.bounds?.width() ?? 0)
+                .attr("height", Math.max(TOP_PAD + 10, 0))
+                .attr("fill", (d: any) => {
+                    const hue = projectHue(d.containerId || d.label || '');
+                    return `hsla(${hue}, 40%, 15%, 0.6)`; // Darker semi-transparent header
+                });
+
             // Epic group labels
             const labelEls = d3.select(hullLayer)
                 .selectAll<SVGTextElement, any>("text.cola-group-label")
-                .data(groups);
+                .data(uniqueGroups, (d: any) => d.containerId || d.label);
 
             labelEls.join("text")
                 .attr("class", "cola-group-label")
@@ -379,7 +423,7 @@
                 .attr("font-weight", 700)
                 .attr("fill", (d: any) => {
                     const hue = projectHue(d.containerId || d.label || '');
-                    return `hsla(${hue}, 40%, 35%, 0.7)`;
+                    return `hsla(${hue}, 60%, 80%, 0.9)`; // Brighter text over the dark header
                 })
                 .style("pointer-events", "none")
                 .style("text-transform", "uppercase")
@@ -389,7 +433,7 @@
                     el.selectAll("tspan").remove();
                     const label = (d.label || "").toUpperCase();
                     const bx = (d.bounds?.x ?? 0) + 12;
-                    const by = (d.bounds?.y ?? 0) + 24;
+                    const by = (d.bounds?.y ?? 0) - TOP_PAD + 22;
                     const availW = Math.max(40, (d.bounds?.width() ?? 200) - 24);
                     const charW = 10; // approximate char width at font-size 18
                     const charsPerLine = Math.max(4, Math.floor(availW / charW));
@@ -426,7 +470,7 @@
         if (!$graphData) return;
 
         // Setup DOM elements
-        if (colaLayout) { colaLayout.stop(); colaLayout = null; }
+        if (simulation) { simulation.stop(); simulation = null; }
 
         const data = $graphData;
 
@@ -483,24 +527,9 @@
         // If nodes are wide+short, it always pushes vertically → vertical stacking.
         // We inflate height padding so the collision box is closer to square,
         // making overlap resolution direction-neutral.
-        const CONTAINER_SCALE = 1.3;
         activeNodes.forEach((n: any) => {
-            if (CONTAINER_TYPES.has(n.type)) {
-                // Epic nodes: full-size collision box, anchored to group center in tickVisuals
-                const scale = CONTAINER_SCALE;
-                n.width = n.w * scale + 40;
-                n.height = n.h * scale + 40;
-                return;
-            }
-            const rawW = n.w;
-            const rawH = n.h;
-            // Use natural dimensions + generous padding.
-            // Wide+short boxes → overlap resolution pushes vertically within groups,
-            // creating compact 2D packing. Global horizontal layout from seeding.
-            // Extra padding for high-priority nodes (glow rings, thicker borders)
-            const priPad = n.priority <= 1 ? 20 : 0;
-            n.width = rawW + 40 + priPad;
-            n.height = rawH + 40 + priPad;
+            n.width = n.w;
+            n.height = n.h;
         });
 
         // Build hierarchical nested groups — epics inside projects, sub-epics inside epics, etc.
@@ -576,8 +605,8 @@
         });
 
         const groupPadding = $viewSettings.colaGroupPadding;
-        const colaGroups: any[] = [];
-        const groupIndexMap = new Map<string, number>(); // containerId → index in colaGroups
+        const d3Groups: any[] = [];
+        const groupIndexMap = new Map<string, number>(); // containerId → index in d3Groups
 
         // Pass 1: Create all container groups (leaves only, groups wired in pass 2)
         for (const cid of containerNodeIds) {
@@ -591,12 +620,12 @@
             }
             const containerNode = nodeById.get(cid);
             const label = containerNode?.label || containerNode?.fullTitle || cid;
-            // Top-level groups get extra padding; nested groups are tighter to keep epics compact
+            // Add extra padding to containers so the top few lines of wrapped text have room
             const isNested = containerParent.get(cid) !== null;
-            const nestPadding = isNested ? groupPadding : groupPadding + 4;
-            const groupIdx = colaGroups.length;
+            const nestPadding = isNested ? Math.max(18, groupPadding + 8) : Math.max(28, groupPadding + 16);
+            const groupIdx = d3Groups.length;
             groupIndexMap.set(cid, groupIdx);
-            colaGroups.push({
+            d3Groups.push({
                 leaves,
                 groups: [],  // filled in pass 2
                 padding: nestPadding,
@@ -611,26 +640,27 @@
             if (pcid && groupIndexMap.has(pcid) && groupIndexMap.has(cid)) {
                 const parentGroupIdx = groupIndexMap.get(pcid)!;
                 const childGroupIdx = groupIndexMap.get(cid)!;
-                colaGroups[parentGroupIdx].groups.push(childGroupIdx);
+                d3Groups[parentGroupIdx].groups.push(childGroupIdx);
             }
         }
+
+        // Convert group indices to actual object references for layoutGroups
+        layoutGroups = d3Groups.map(g => ({ ...g, groups: [] })); // shadow copy
+        d3Groups.forEach((g, i) => {
+            layoutGroups[i].groups = (g.groups as number[]).map(idx => layoutGroups[idx]);
+        });
 
         // Mark which container nodes have a group box — their node visual will be hidden
         containerGroupNodeIds = new Set(groupIndexMap.keys());
 
-        // Put ungrouped nodes in a catch-all group so Cola keeps them outside epic containers
+        // Put ungrouped nodes in a catch-all group
         if (ungroupedIndices.length > 0) {
-            colaGroups.push({ leaves: ungroupedIndices, groups: [], padding: groupPadding, label: '' });
+            layoutGroups.push({ leaves: ungroupedIndices, groups: [], padding: groupPadding, label: '' });
         }
 
         // Pre-compute node→group membership for edge routing (avoids per-tick allocation).
-        // Resolve numeric child-group indices to actual group objects first, then walk the tree.
         layoutNodeGroupSets = new Map();
         {
-            const resolvedGroups = colaGroups.map(g => ({
-                ...g,
-                groups: (g.groups as number[]).map(idx => colaGroups[idx])
-            }));
             function addNGS(nodeId: string, gId: string) {
                 if (!layoutNodeGroupSets.has(nodeId)) layoutNodeGroupSets.set(nodeId, new Set());
                 layoutNodeGroupSets.get(nodeId)!.add(gId);
@@ -649,8 +679,8 @@
                 });
             }
             const nestedResolved = new Set<any>();
-            resolvedGroups.forEach(g => (g.groups || []).forEach((c: any) => nestedResolved.add(c)));
-            resolvedGroups.forEach(g => {
+            layoutGroups.forEach(g => (g.groups || []).forEach((c: any) => nestedResolved.add(c)));
+            layoutGroups.forEach(g => {
                 if (!nestedResolved.has(g) && g.label) buildGroupMembership(g, []);
             });
         }
@@ -681,56 +711,65 @@
             }
         }
 
-        // Pre-compute nested-group set for hull rendering — group topology is stable per layout.
-        // Only bounds change per tick; nesting structure is fixed after colaGroups is built.
+        // Pre-compute nested-group set for hull rendering
         layoutNestedGroupSet = new Set<any>();
-        colaGroups.forEach((g: any) => {
-            (g.groups as number[]).forEach((childIdx: number) => {
-                layoutNestedGroupSet.add(colaGroups[childIdx]);
+        layoutGroups.forEach((g: any) => {
+            (g.groups as any[]).forEach((child: any) => {
+                layoutNestedGroupSet.add(child);
             });
         });
 
         // Initial positions: lay out top-level groups in a wide horizontal grid,
         // then scatter child groups and leaves near their parent's center.
-        // Bias toward horizontal spread so the graph doesn't stack vertically.
         const pad = 200;
-        const groupSeeded = new Set<number>();
+        const groupSeeded = new Set<any>();
 
-        function seedGroupPositions(groupIdx: number, cx: number, cy: number, spreadX: number, spreadY: number) {
-            if (groupSeeded.has(groupIdx)) return;
-            groupSeeded.add(groupIdx);
-            const group = colaGroups[groupIdx];
-            // Place direct leaf nodes near group center — wider horizontal scatter
-            (group.leaves as number[]).forEach((idx: number) => {
+        function seedGroupPositions(group: any, cx: number, cy: number, spreadX: number, spreadY: number) {
+            if (groupSeeded.has(group)) return;
+            groupSeeded.add(group);
+            
+            // Place the container node exactly at the center
+            const leaves = group.leaves as number[];
+            const containerIdx = leaves.find((idx: number) => activeNodes[idx].id === group.containerId);
+            if (containerIdx !== undefined) {
+                const n = activeNodes[containerIdx] as any;
+                n.x = cx;
+                n.y = cy;
+            }
+
+            const childLeaves = leaves.filter((idx: number) => activeNodes[idx].id !== group.containerId);
+            childLeaves.forEach((idx: number) => {
                 const n = activeNodes[idx] as any;
-                n.x = cx + (Math.random() - 0.5) * spreadX * 0.4;
-                n.y = cy + (Math.random() - 0.5) * spreadY * 0.3;
+                n.x = cx + (Math.random() - 0.5) * 5;
+                n.y = cy + (Math.random() - 0.5) * 5;
             });
-            // Recursively seed child groups near this center
-            (group.groups as number[]).forEach((childIdx: number) => {
-                const childCx = cx + (Math.random() - 0.5) * spreadX * 0.5;
-                const childCy = cy + (Math.random() - 0.5) * spreadY * 0.4;
-                seedGroupPositions(childIdx, childCx, childCy, spreadX * 0.6, spreadY * 0.6);
-            });
+
+            const childGroupCount = (group.groups as any[]).length;
+            if (childGroupCount > 0) {
+                const angleStep = (Math.PI * 2) / childGroupCount;
+                const radius = Math.max(spreadX, spreadY) * 1.5; 
+                (group.groups as any[]).forEach((child: any, i: number) => {
+                    const angle = i * angleStep;
+                    const childCx = cx + Math.cos(angle) * radius;
+                    const childCy = cy + Math.sin(angle) * radius;
+                    seedGroupPositions(child, childCx, childCy, spreadX * 0.8, spreadY * 0.8);
+                });
+            }
         }
 
-        // Find top-level groups (not nested inside any other group)
-        const nestedGroupIndices = new Set<number>();
-        colaGroups.forEach(g => (g.groups as number[]).forEach((ci: number) => nestedGroupIndices.add(ci)));
-
-        const topGroups = colaGroups.map((g, i) => i).filter(i => !nestedGroupIndices.has(i));
+        const topGroups = layoutGroups.filter(g => !layoutNestedGroupSet.has(g));
         // Arrange top-level groups in a horizontal row with wrapping
         const cols = Math.max(1, Math.ceil(Math.sqrt(topGroups.length * (cw / ch))));
         const rows = Math.ceil(topGroups.length / cols);
         const cellW = (cw - pad * 2) / cols;
         const cellH = (ch - pad * 2) / rows;
 
-        topGroups.forEach((groupIdx, i) => {
+        topGroups.forEach((group, i) => {
             const col = i % cols;
             const row = Math.floor(i / cols);
             const cx = pad + cellW * (col + 0.5) + (Math.random() - 0.5) * cellW * 0.3;
             const cy = pad + cellH * (row + 0.5) + (Math.random() - 0.5) * cellH * 0.3;
-            seedGroupPositions(groupIdx, cx, cy, cellW * 0.7, cellH * 0.6);
+            seedGroupPositions(group, cx, cy, cellW * 0.7, cellH * 0.6);
         });
         // Any nodes not in any group (shouldn't happen, but safety)
         activeNodes.forEach((d: any) => {
@@ -762,13 +801,8 @@
 
         bindDragAndClick(nEls);
 
-        // Filter out parent edges involving container-group nodes — the box shows hierarchy.
-        const visualLinks = activeLinks.filter((l: any) => {
-            if (l.type !== 'parent') return true;
-            const sid = typeof l.source === 'object' ? l.source.id : l.source;
-            const tid = typeof l.target === 'object' ? l.target.id : l.target;
-            return !containerGroupNodeIds.has(sid) && !containerGroupNodeIds.has(tid);
-        });
+        // Filter out parent edges — the bounding boxes show the hierarchy.
+        const visualLinks = activeLinks.filter((l: any) => l.type !== 'parent');
 
         const eEls = d3
             .select(edgesLayer)
@@ -788,30 +822,41 @@
         routeSfdpEdges(eEls);
         updateHulls();
 
-        // --- Phase 3: Start Cola layout ---
-        const colaLinks = parentLinks.map((l: any) => {
-            const si = nodeIndex.get(typeof l.source === 'object' ? l.source.id : l.source)!;
-            const ti = nodeIndex.get(typeof l.target === 'object' ? l.target.id : l.target)!;
-            return { source: si, target: ti };
-        }).filter((l: any) => l.source !== undefined && l.target !== undefined);
+        // --- Phase 3: Start D3 layout ---
+        const d3Links = activeLinks.map((l: any) => {
+            const sid = typeof l.source === 'object' ? l.source.id : l.source;
+            const tid = typeof l.target === 'object' ? l.target.id : l.target;
+            if (!sid || !tid) return null;
+            
+            let length = $viewSettings.colaLinkLength || 35;
+            let strength = 1.0;
+            
+            if (l.type === 'parent') {
+                length = length * 0.8;
+                strength = 2.0; 
+            } else if (l.type === 'depends_on') {
+                length = length * 1.2; 
+                strength = 0.5;
+            } else {
+                length = length * 1.4; 
+                strength = 0.2; 
+            }
+            return { source: sid, target: tid, length, strength, type: l.type };
+        }).filter((l: any) => l !== null) as any[];
 
-        const nestedCount = colaGroups.filter(g => (g.groups || []).length > 0).length;
-        console.log(`[Cola] ${activeNodes.length} nodes, ${colaLinks.length} links, ${colaGroups.length} groups (${nestedCount} with children)`, colaGroups.map(g => `${g.leaves.length}L${(g.groups||[]).length ? '+' + (g.groups||[]).length + 'G' : ''}`));
+        const nestedCount = layoutGroups.filter(g => (g.groups || []).length > 0).length;
+        console.log(`[D3 Force] ${activeNodes.length} nodes, ${d3Links.length} links, ${layoutGroups.length} groups (${nestedCount} with children)`);
 
-        colaLayout = cola.d3adaptor(d3)
-            .size([cw, ch])
-            .nodes(activeNodes as any)
-            .links(colaLinks)
-            .groups(colaGroups)
-            .avoidOverlaps(true)
-            .handleDisconnected(true)
-            .symmetricDiffLinkLengths($viewSettings.colaLinkLength, 0.7)
-            .on("tick", tickVisuals)
-            .start(30, 30, 30);
+        simulation = d3.forceSimulation(activeNodes as any)
+            .force("link", d3.forceLink(d3Links).id((d: any) => d.id).distance((d: any) => d.length).strength((d: any) => d.strength))
+            .force("charge", d3.forceManyBody().strength(-300))
+            .force("center", d3.forceCenter(cw / 2, ch / 2))
+            .force("collide", d3.forceCollide().radius((d: any) => Math.max(d.w || 0, d.h || 0) / 2 + 10))
+            .on("tick", tickVisuals);
     }
 
     onDestroy(() => {
-        if (colaLayout) colaLayout.stop();
+        if (simulation) simulation.stop();
         cancelAnimationFrame(frameId);
     });
 </script>

--- a/overwhelm-dashboard/src/lib/components/views/MetroView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/MetroView.svelte
@@ -206,6 +206,13 @@
                         'overlay-opacity': 0.12,
                     } as any,
                 },
+                // Filter-dimmed nodes
+                {
+                    selector: 'node[?filter_dimmed]',
+                    style: {
+                        'opacity': 0.15,
+                    } as any,
+                },
                 // High-priority container stations — extra prominent
                 {
                     selector: 'node[?isHighPriority][?isContainer]',

--- a/overwhelm-dashboard/src/lib/components/views/TaskEditorView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/TaskEditorView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { graphData } from "../../stores/graph";
     import HierarchyTree from "./HierarchyTree.svelte";
+    import { toast } from "../../stores/toast";
     import {
         TYPE_CHARGE,
         STATUS_FILLS,
@@ -62,15 +63,15 @@
     const statusOptions = Object.keys(STATUS_FILLS).sort();
     const typeOptions = Object.keys(TYPE_CHARGE).sort();
 
-    async function updateTask(updates: Record<string, any>) {
-        if (!taskId || !task) return;
+    async function updateTask(updates: Record<string, any>, targetId: string | null = taskId) {
+        if (!targetId) return;
 
         // Optimistic local update — mutate the existing node in place so Cola's
         // internal references stay valid and graphStructureKey doesn't change.
         // This avoids a full physics rebuild for property-only edits.
         graphData.update(gd => {
             if (!gd) return gd;
-            const node = gd.nodes.find(n => n.id === taskId);
+            const node = gd.nodes.find(n => n.id === targetId);
             if (node) {
                 Object.assign(node, updates);
                 if (updates.status) {
@@ -85,7 +86,7 @@
         });
 
         // Persist via API — send any fields that the endpoint accepts
-        const apiPayload: Record<string, unknown> = { id: taskId };
+        const apiPayload: Record<string, unknown> = { id: targetId };
         if (updates.status) apiPayload.status = updates.status;
         if (updates.priority !== undefined) apiPayload.priority = updates.priority;
         if (updates.assignee !== undefined) apiPayload.assignee = updates.assignee;
@@ -102,9 +103,13 @@
                 if (!res.ok) {
                     const data = await res.json().catch(() => ({}));
                     updateError = data.error ?? `HTTP ${res.status}`;
+                    toast.show(`Failed to update ${targetId}: ${updateError}`, 'error');
+                } else {
+                    toast.show(`Successfully updated ${targetId}`, 'success');
                 }
             } catch (e: any) {
                 updateError = e.message ?? 'Network error';
+                toast.show(`Error: ${updateError}`, 'error');
             } finally {
                 updating = false;
             }
@@ -152,13 +157,29 @@
     function priorityUp() {
         if (!task) return;
         const current = task.priority ?? 2;
-        if (current > 0) setPriority(current - 1);
+        if (current > 0) {
+            setPriority(current - 1);
+            if (task.type === 'epic') {
+                activeChildren.forEach(child => {
+                    const cPri = child.priority ?? 2;
+                    if (cPri > 0) updateTask({ priority: cPri - 1 }, child.id);
+                });
+            }
+        }
     }
 
     function priorityDown() {
         if (!task) return;
         const current = task.priority ?? 2;
-        if (current < 4) setPriority(current + 1);
+        if (current < 4) {
+            setPriority(current + 1);
+            if (task.type === 'epic') {
+                activeChildren.forEach(child => {
+                    const cPri = child.priority ?? 2;
+                    if (cPri < 4) updateTask({ priority: cPri + 1 }, child.id);
+                });
+            }
+        }
     }
 
     function handleArchive() {
@@ -183,6 +204,7 @@
             });
             if (res.ok) {
                 refileMarked = true;
+                toast.show(`Task ${taskId} marked for refile`, 'success');
                 // Also optimistically mark it in-graph
                 graphData.update(gd => {
                     if (!gd) return gd;
@@ -195,9 +217,11 @@
             } else {
                 const data = await res.json().catch(() => ({}));
                 updateError = data.error ?? `HTTP ${res.status}`;
+                toast.show(`Failed to mark refile: ${updateError}`, 'error');
             }
         } catch (e: any) {
             updateError = e.message ?? 'Network error';
+            toast.show(`Error: ${updateError}`, 'error');
         } finally {
             updating = false;
         }

--- a/overwhelm-dashboard/src/lib/components/views/ThreadedTasksView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/ThreadedTasksView.svelte
@@ -2,6 +2,7 @@
     import { graphData } from "../../stores/graph";
     import { selection } from "../../stores/selection";
     import { filters } from "../../stores/filters";
+    import { toast } from "../../stores/toast";
     import { PRIORITIES } from "../../data/constants";
     import { projectHue } from "../../data/projectUtils";
     import TaskEditorView from "./TaskEditorView.svelte";
@@ -21,8 +22,22 @@
     }
 
     function selectProject(p: string | 'ALL') {
-        filters.update(f => ({ ...f, project: p }));
+        filters.update(f => {
+            if (p === 'ALL') {
+                return { ...f, hiddenProjects: [] };
+            } else {
+                return { ...f, hiddenProjects: projects.filter(proj => proj !== p) };
+            }
+        });
     }
+
+    $: isAllProjects = ($filters.hiddenProjects?.length ?? 0) === 0;
+    // Determine which project is active in the sidebar. 
+    // If exactly one project is visible (all others are hidden), consider it active.
+    $: activeProject = isAllProjects ? 'ALL' : 
+        (projects.length > 0 && ($filters.hiddenProjects?.length ?? 0) === projects.length - 1) 
+        ? projects.find(p => !($filters.hiddenProjects?.includes(p))) 
+        : 'MIXED';
 
     function toggleSort(field: string) {
         if (sortField === field) {
@@ -50,13 +65,19 @@
 
         // Persist
         try {
-            await fetch('/api/task/status', {
+            const res = await fetch('/api/task/status', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ id: task.id, status: newStatus })
             });
-        } catch (e) {
+            if (res.ok) {
+                toast.show(`Marked as ${newStatus}`, 'success');
+            } else {
+                toast.show(`Failed to update status`, 'error');
+            }
+        } catch (e: any) {
             console.error("Failed to update task status", e);
+            toast.show(`Error: ${e.message}`, 'error');
         }
     }
 
@@ -64,7 +85,7 @@
 
     $: tasks = $graphData ? $graphData.nodes.filter(n => {
         const matchesType = n.type === 'task';
-        const matchesProject = $filters.project === 'ALL' || n.project === $filters.project;
+        const matchesProject = !($filters.hiddenProjects?.includes(n.project || ''));
 
         let matchesTab = false;
         if (currentTab === 'ACTIVE_TASKS') {
@@ -122,7 +143,7 @@
             <div class="mb-2">
                 <button
                     class="flex items-center gap-2 p-2 w-full text-left rounded transition-colors group
-                    {$filters.project === 'ALL' ? 'text-primary bg-primary/20 border-l-2 border-primary' : 'text-primary/60 hover:bg-primary/10'}"
+                    {activeProject === 'ALL' ? 'text-primary bg-primary/20 border-l-2 border-primary' : 'text-primary/60 hover:bg-primary/10'}"
                     onclick={() => selectProject('ALL')}
                 >
                     <span class="material-symbols-outlined text-lg">target</span>
@@ -134,16 +155,21 @@
                             <div class="flex items-center gap-1 group">
                                 <button
                                     class="flex-1 flex items-center gap-2 p-1.5 text-left rounded cursor-pointer transition-colors
-                                    {$filters.project === project ? 'text-primary bg-primary/20' : 'text-primary/80 hover:bg-primary/10'}"
+                                    {activeProject === project ? 'text-primary bg-primary/20' : 'text-primary/80 hover:bg-primary/10'}"
                                     style="border-left: 3px solid hsl({projectHue(project)}, 45%, 45%);"
                                     onclick={() => selectProject(project)}
                                 >
-                                    <span class="material-symbols-outlined text-base">{$filters.project === project || expandedProjects[project] ? 'folder_open' : 'folder'}</span>
+                                    <span class="material-symbols-outlined text-base">{activeProject === project || expandedProjects[project] ? 'folder_open' : 'folder'}</span>
                                     <span class="truncate">{project}</span>
                                 </button>
                                 <button
                                     class="p-1 text-primary/40 hover:text-primary transition-colors"
-                                    onclick={(e) => { e.stopPropagation(); toggleProject(project); }}
+                                    onclick={(e) => { e.stopPropagation(); filters.update(f => {
+                                        const hidden = f.hiddenProjects || [];
+                                        return hidden.includes(project) 
+                                            ? { ...f, hiddenProjects: hidden.filter(p => p !== project) }
+                                            : { ...f, hiddenProjects: [...hidden, project] };
+                                    }); }}
                                 >
                                     <span class="material-symbols-outlined text-sm">{expandedProjects[project] ? 'expand_more' : 'chevron_right'}</span>
                                 </button>
@@ -176,7 +202,7 @@
             <div class="flex items-center gap-2 text-primary/60 text-sm font-mono">
                 <button class="hover:text-primary transition-colors cursor-pointer" onclick={() => selectProject('ALL')}>WORKSPACE</button>
                 <span class="material-symbols-outlined text-xs">chevron_right</span>
-                <span class="text-primary font-bold">{$filters.project === 'ALL' ? 'ALL_TASKS' : $filters.project.toUpperCase()}</span>
+                <span class="text-primary font-bold">{activeProject === 'ALL' ? 'ALL_TASKS' : (activeProject || '').toUpperCase()}</span>
             </div>
             
             <div class="ml-4 flex-1">

--- a/overwhelm-dashboard/src/lib/components/views/TreemapView.svelte
+++ b/overwhelm-dashboard/src/lib/components/views/TreemapView.svelte
@@ -232,15 +232,16 @@
             }
         });
 
-        // Gentle dimming: non-focus leaf nodes slightly faded
+        // Gentle dimming: non-focus leaf nodes slightly faded, and filter-dimmed nodes heavily faded
         if (showFocus) {
             nEls.style("opacity", (d: any) => {
+                if (d.filter_dimmed) return 0.2;
                 if (!d._isLeaf) return null; // Don't dim containers
                 if (focusIds.has(d.id)) return 1;
                 return 0.65;
             });
         } else {
-            nEls.style("opacity", null);
+            nEls.style("opacity", (d: any) => d.filter_dimmed ? 0.2 : null);
         }
 
         const eEls = d3

--- a/overwhelm-dashboard/src/lib/stores/filters.ts
+++ b/overwhelm-dashboard/src/lib/stores/filters.ts
@@ -1,22 +1,30 @@
 import { writable } from 'svelte/store';
 
-/** Edge visibility: 'bright' (full), 'half' (dim), 'hidden' (invisible) */
-export type EdgeVisibility = 'bright' | 'half' | 'hidden';
+/** Visibility state: 'bright' (full), 'half' (dim), 'hidden' (invisible) */
+export type VisibilityState = 'bright' | 'half' | 'hidden';
 
-export function cycleEdgeVisibility(current: EdgeVisibility): EdgeVisibility {
+export function cycleVisibility(current: VisibilityState): VisibilityState {
     if (current === 'bright') return 'half';
     if (current === 'half') return 'hidden';
     return 'bright';
 }
 
 export const filters = writable({
-    project: 'ALL',
-    showActive: true,
-    showBlocked: true,
-    showCompleted: false,
-    showOrphans: false,
-    priorityFilter: null as number | null,
-    edgeDependencies: 'half' as EdgeVisibility,
-    edgeReferences: 'hidden' as EdgeVisibility,
-    edgeParent: 'bright' as EdgeVisibility,
+    statusActive: 'bright' as VisibilityState,
+    statusBlocked: 'bright' as VisibilityState,
+    statusCompleted: 'hidden' as VisibilityState,
+    statusOrphans: 'hidden' as VisibilityState,
+    
+    // Default all priorities to bright
+    priority0: 'bright' as VisibilityState,
+    priority1: 'bright' as VisibilityState,
+    priority2: 'bright' as VisibilityState,
+    priority3: 'bright' as VisibilityState,
+    priority4: 'bright' as VisibilityState,
+
+    hiddenProjects: [] as string[],
+    
+    edgeDependencies: 'half' as VisibilityState,
+    edgeReferences: 'hidden' as VisibilityState,
+    edgeParent: 'bright' as VisibilityState,
 });

--- a/overwhelm-dashboard/src/lib/stores/toast.ts
+++ b/overwhelm-dashboard/src/lib/stores/toast.ts
@@ -1,0 +1,30 @@
+import { writable } from 'svelte/store';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+export interface ToastMessage {
+    id: number;
+    message: string;
+    type: ToastType;
+}
+
+function createToastStore() {
+    const { subscribe, update } = writable<ToastMessage[]>([]);
+    let nextId = 0;
+
+    return {
+        subscribe,
+        show: (message: string, type: ToastType = 'info', timeoutMs: number = 3000) => {
+            const id = nextId++;
+            update(msgs => [...msgs, { id, message, type }]);
+            setTimeout(() => {
+                update(msgs => msgs.filter(m => m.id !== id));
+            }, timeoutMs);
+        },
+        remove: (id: number) => {
+            update(msgs => msgs.filter(m => m.id !== id));
+        }
+    };
+}
+
+export const toast = createToastStore();

--- a/overwhelm-dashboard/src/lib/stores/viewSettings.ts
+++ b/overwhelm-dashboard/src/lib/stores/viewSettings.ts
@@ -9,9 +9,9 @@ export const viewSettings = writable({
     topNLeaves: 80,
     chargeStrength: 1.0,  // unused (legacy d3 force)
     linkDistance: 1.0,     // unused (legacy d3 force)
-    colaLinkLength: 60,    // ideal link length (symmetricDiffLinkLengths)
-    colaFlowSep: 40,       // min vertical separation between linked nodes
-    colaGroupPadding: 8,   // padding inside epic group hulls — keeps non-descendants out
+    colaLinkLength: 35,    // ideal link length (symmetricDiffLinkLengths)
+    colaFlowSep: 30,       // min vertical separation between linked nodes
+    colaGroupPadding: 6,   // padding inside epic group hulls — keeps non-descendants out
     circleRollupThreshold: 15,
     arcVerticalSpacing: 1.0,
     treemapWeightMode: 'priority' as 'sqrt' | 'priority' | 'dw-bucket' | 'equal',

--- a/overwhelm-dashboard/src/routes/+layout.svelte
+++ b/overwhelm-dashboard/src/routes/+layout.svelte
@@ -3,10 +3,12 @@
 	import "../app.css";
 	import { viewSettings, VIEW_MODES } from "$lib/stores/viewSettings";
 	import QuickCapture from "$lib/components/dashboard/QuickCapture.svelte";
+	import Toast from "$lib/components/shared/Toast.svelte";
 
 	let { children } = $props();
 </script>
 
+<Toast />
 <svelte:head>
 	<link rel="icon" href={favicon} />
 </svelte:head>

--- a/overwhelm-dashboard/src/routes/+page.svelte
+++ b/overwhelm-dashboard/src/routes/+page.svelte
@@ -89,32 +89,42 @@
             return n._raw?.task_id != null && n._raw?.status && n._raw.status.trim() !== "" && n.status !== "inbox";
         });
 
-        if (!$filters.showActive) {
-            fNodes = fNodes.filter(
-                (n) => !["active", "inbox", "todo", "in_progress", "review", "waiting", "decomposing", "dormant"].includes(n.status),
-            );
-        }
-        if (!$filters.showBlocked) {
-            fNodes = fNodes.filter((n) => n.status !== "blocked");
-        }
-        if (!$filters.showCompleted) {
-            fNodes = fNodes.filter(
-                (n) => !["done", "completed", "cancelled", "historical", "deferred", "paused", "seed", "early-scaffold"].includes(n.status),
-            );
-        }
-        // Priority filter from legend
-        if ($filters.priorityFilter !== null) {
-            const pf = $filters.priorityFilter;
-            fNodes = fNodes.filter(
-                (n) => STRUCTURAL_TYPES.has(n.type) || n.priority === pf,
-            );
-        }
-        if (isForce && $filters.project !== "ALL") {
-            fNodes = fNodes.filter(
-                (n) => n.project === $filters.project || n.type === "project" || n.type === "goal",
-            );
-        }
-        if ($viewSettings.viewMode === "Force" && !$filters.showOrphans) {
+        // Tri-state Visibility Filters
+        fNodes = fNodes.filter(n => {
+            // Projects are still boolean
+            if (($filters.hiddenProjects?.length ?? 0) > 0 && $filters.hiddenProjects.includes(n.project || "")) {
+                return false;
+            }
+
+            let visState = 'bright';
+
+            // Determine status visibility
+            let statusVis = 'bright';
+            const isActive = ["active", "inbox", "todo", "in_progress", "review", "waiting", "decomposing", "dormant"].includes(n.status);
+            const isBlocked = n.status === "blocked";
+            const isCompleted = ["done", "completed", "cancelled", "historical", "deferred", "paused", "seed", "early-scaffold"].includes(n.status);
+            
+            if (isActive) statusVis = $filters.statusActive;
+            else if (isBlocked) statusVis = $filters.statusBlocked;
+            else if (isCompleted) statusVis = $filters.statusCompleted;
+
+            let priVis = 'bright';
+            if (!STRUCTURAL_TYPES.has(n.type)) {
+                if (n.priority === 0) priVis = $filters.priority0;
+                else if (n.priority === 1) priVis = $filters.priority1;
+                else if (n.priority === 2) priVis = $filters.priority2;
+                else if (n.priority === 3) priVis = $filters.priority3;
+                else if (n.priority === 4) priVis = $filters.priority4;
+            }
+
+            if (statusVis === 'hidden' || priVis === 'hidden') return false;
+            if (statusVis === 'half' || priVis === 'half') visState = 'half';
+            
+            (n as any).filter_dimmed = (visState === 'half');
+            return true;
+        });
+
+        if ($viewSettings.viewMode === "Force" && $filters.statusOrphans === 'hidden') {
             const nodesWithEdges = new Set<string>();
             fLinks.forEach((l) => {
                 const sid = typeof l.source === "object" ? l.source.id : l.source;

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -171,31 +171,26 @@ impl PkbSearchServer {
     // =========================================================================
 
     fn handle_get_document(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
-        let path_str = args
-            .get("path")
+        // Accept `id` (preferred) or `path` (legacy) — both resolve via the graph
+        let query = args
+            .get("id")
             .and_then(|v| v.as_str())
+            .or_else(|| args.get("path").and_then(|v| v.as_str()))
             .ok_or_else(|| McpError {
                 code: ErrorCode::INVALID_PARAMS,
-                message: Cow::from("Missing required parameter: path"),
+                message: Cow::from("Missing required parameter: id (or path)"),
                 data: None,
             })?;
 
-        let path = self.resolve_path(path_str);
-
-        // If the path doesn't exist on disk, try flexible ID resolution via the graph
-        let path = if !path.exists() {
+        // Try ID/flexible resolution first (covers IDs, filename stems, titles, permalinks)
+        let path = {
             let graph = self.graph.read();
-            if let Some(node) = graph.resolve(path_str) {
+            if let Some(node) = graph.resolve(query) {
                 self.abs_path(&node.path)
             } else {
-                return Err(McpError {
-                    code: ErrorCode::INVALID_PARAMS,
-                    message: Cow::from(format!("File not found: {}", path.display())),
-                    data: None,
-                });
+                // Fall back to treating the value as a literal path
+                self.resolve_path(query)
             }
-        } else {
-            path
         };
 
         if !path.exists() {
@@ -2889,13 +2884,13 @@ impl ServerHandler for PkbSearchServer {
             ),
             Tool::new(
                 "get_document",
-                "Read the full contents of a specific PKB document.",
+                "Read the full contents of a specific PKB document. Accepts an ID (preferred), filename stem, title, permalink, or path — uses flexible resolution.",
                 serde_json::from_value::<JsonObject>(serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "path": { "type": "string", "description": "Path to document" }
-                    },
-                    "required": ["path"]
+                        "id": { "type": "string", "description": "Document ID, filename stem, title, or permalink (preferred — uses flexible resolution)" },
+                        "path": { "type": "string", "description": "Path to document (legacy — use id instead)" }
+                    }
                 }))
                 .unwrap(),
             ),

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -2890,7 +2890,11 @@ impl ServerHandler for PkbSearchServer {
                     "properties": {
                         "id": { "type": "string", "description": "Document ID, filename stem, title, or permalink (preferred — uses flexible resolution)" },
                         "path": { "type": "string", "description": "Path to document (legacy — use id instead)" }
-                    }
+                    },
+                    "anyOf": [
+                        { "required": ["id"] },
+                        { "required": ["path"] }
+                    ]
                 }))
                 .unwrap(),
             ),


### PR DESCRIPTION
## Summary

- `get_document` now accepts `id` (document ID, filename stem, title, or permalink) as the primary parameter — uses the same flexible graph resolution as `get_task`/`update_task`
- `path` is kept as a legacy fallback so existing callers don't break
- Resolution order: `id` param first → `path` param second → `graph.resolve()` for both → literal path fallback
- Schema updated: `path` is no longer `required`; `id` is the documented preferred interface

## What this fixes

MCP clients (Cowork agents, GHA agents, Dispatch) don't have direct filesystem access, so `path`-based parameters were unusable — they had to guess or hardcode paths. With `id` as the primary interface, any client can use the document's ID returned from `search`, `task_search`, `list_tasks`, etc. directly into `get_document`.

## Audit findings

Only two tools had `path` as an input parameter:
- `get_document` — fixed in this PR  
- `update_task` — already had `id`/`path` dual parameters, no changes needed

## Test plan

- [x] `cargo check` — clean (pre-existing warnings only)
- [x] `cargo test --lib` — 123 tests pass
- [ ] Manual: call `get_document` with an ID from a `search` result

🤖 Generated with [Claude Code](https://claude.com/claude-code)