### PR TITLE
fix(mcp): implement CRUD redesign phase 0-2

### DIFF
--- a/src/batch_ops/update.rs
+++ b/src/batch_ops/update.rs
@@ -119,7 +119,16 @@ pub fn batch_update(
         }
 
         // Build the effective updates for this node
-        let effective = build_effective_updates(updates_map, node);
+        let effective = match crate::document_crud::expand_special_update_keys(node, updates_map) {
+            Ok(e) => e,
+            Err(e) => {
+                summary.errors.push(TaskError {
+                    id: id.clone(),
+                    error: e.to_string(),
+                });
+                continue;
+            }
+        };
         if effective.is_empty() {
             summary.skipped += 1;
             summary.tasks.push(TaskAction {
@@ -292,122 +301,6 @@ pub fn batch_archive(
     summary
 }
 
-/// Build the effective update HashMap for a node, handling special keys.
-fn build_effective_updates(
-    updates_map: &serde_json::Map<String, serde_json::Value>,
-    node: &crate::graph::GraphNode,
-) -> HashMap<String, serde_json::Value> {
-    let mut effective = HashMap::new();
-
-    for (key, value) in updates_map {
-        if SPECIAL_KEYS.contains(&key.as_str()) {
-            continue; // Handle below
-        }
-
-        // Check if this would be a no-op
-        let is_noop = match key.as_str() {
-            "status" => node.status.as_deref() == value.as_str(),
-            "priority" => node.priority == value.as_i64().map(|v| v as i32),
-            "assignee" => node.assignee.as_deref() == value.as_str(),
-            "complexity" => node.complexity.as_deref() == value.as_str(),
-            "parent" => node.parent.as_deref() == value.as_str(),
-            _ => false,
-        };
-
-        if !is_noop {
-            effective.insert(key.clone(), value.clone());
-        }
-    }
-
-    // Handle _add_tags
-    if let Some(add_tags) = updates_map.get("_add_tags").and_then(|v| v.as_array()) {
-        let new_tags: Vec<String> = add_tags
-            .iter()
-            .filter_map(|v| v.as_str().map(String::from))
-            .filter(|t| !node.tags.contains(t))
-            .collect();
-        if !new_tags.is_empty() {
-            let mut all_tags = node.tags.clone();
-            all_tags.extend(new_tags);
-            effective.insert(
-                "tags".to_string(),
-                serde_json::Value::Array(all_tags.into_iter().map(serde_json::Value::String).collect()),
-            );
-        }
-    }
-
-    // Handle _remove_tags
-    if let Some(remove_tags) = updates_map.get("_remove_tags").and_then(|v| v.as_array()) {
-        let remove_set: std::collections::HashSet<&str> = remove_tags
-            .iter()
-            .filter_map(|v| v.as_str())
-            .collect();
-        if node.tags.iter().any(|t| remove_set.contains(t.as_str())) {
-            let remaining: Vec<String> = node
-                .tags
-                .iter()
-                .filter(|t| !remove_set.contains(t.as_str()))
-                .cloned()
-                .collect();
-            effective.insert(
-                "tags".to_string(),
-                serde_json::Value::Array(remaining.into_iter().map(serde_json::Value::String).collect()),
-            );
-        }
-    }
-
-    // Handle _add_depends_on
-    if let Some(add_deps) = updates_map.get("_add_depends_on").and_then(|v| v.as_array()) {
-        let new_deps: Vec<String> = add_deps
-            .iter()
-            .filter_map(|v| v.as_str().map(String::from))
-            .filter(|d| !node.depends_on.contains(d))
-            .collect();
-        if !new_deps.is_empty() {
-            let mut all_deps = node.depends_on.clone();
-            all_deps.extend(new_deps);
-            effective.insert(
-                "depends_on".to_string(),
-                serde_json::Value::Array(all_deps.into_iter().map(serde_json::Value::String).collect()),
-            );
-        }
-    }
-
-    // Handle _remove_depends_on
-    if let Some(remove_deps) = updates_map.get("_remove_depends_on").and_then(|v| v.as_array()) {
-        let remove_set: std::collections::HashSet<&str> = remove_deps
-            .iter()
-            .filter_map(|v| v.as_str())
-            .collect();
-        if node.depends_on.iter().any(|d| remove_set.contains(d.as_str())) {
-            let remaining: Vec<String> = node
-                .depends_on
-                .iter()
-                .filter(|d| !remove_set.contains(d.as_str()))
-                .cloned()
-                .collect();
-            effective.insert(
-                "depends_on".to_string(),
-                serde_json::Value::Array(remaining.into_iter().map(serde_json::Value::String).collect()),
-            );
-        }
-    }
-
-    // Handle superseded_by (sets status to done + superseded_by field)
-    if let Some(superseded_by) = updates_map.get("superseded_by") {
-        effective.insert("superseded_by".to_string(), superseded_by.clone());
-        if !effective.contains_key("status") {
-            effective.insert(
-                "status".to_string(),
-                serde_json::Value::String("done".to_string()),
-            );
-        }
-    }
-
-    effective
-}
-
-/// Describe updates in human-readable form.
 fn describe_updates(updates: &HashMap<String, serde_json::Value>) -> String {
     updates
         .iter()

--- a/src/batch_ops/update.rs
+++ b/src/batch_ops/update.rs
@@ -9,14 +9,6 @@ use crate::graph_store::GraphStore;
 use std::collections::HashMap;
 use std::path::Path;
 
-/// Special update keys that get transformed (not set directly).
-const SPECIAL_KEYS: &[&str] = &[
-    "_add_tags",
-    "_remove_tags",
-    "_add_depends_on",
-    "_remove_depends_on",
-];
-
 /// Execute a batch update operation.
 ///
 /// Applies `updates` to all tasks matching `filters`. Supports special

--- a/src/document_crud.rs
+++ b/src/document_crud.rs
@@ -2517,3 +2517,129 @@ pub fn merge_node(
         modified_paths,
     })
 }
+
+
+// ── Special Keys Expansion ──────────────────────────────────────────────────────────
+
+/// Expand special update keys like `_add_depends_on` and `_remove_tags` into effective document state updates.
+pub fn expand_special_update_keys(
+    node: &crate::graph::GraphNode,
+    updates_map: &serde_json::Map<String, serde_json::Value>,
+) -> anyhow::Result<std::collections::HashMap<String, serde_json::Value>> {
+    let mut effective = std::collections::HashMap::new();
+    let special_keys = ["_add_tags", "_remove_tags", "_add_depends_on", "_remove_depends_on", "superseded_by"];
+
+    for (key, value) in updates_map {
+        if special_keys.contains(&key.as_str()) {
+            continue;
+        }
+
+        let is_noop = match key.as_str() {
+            "status" => node.status.as_deref() == value.as_str(),
+            "priority" => node.priority == value.as_i64().map(|v| v as i32),
+            "assignee" => node.assignee.as_deref() == value.as_str(),
+            "complexity" => node.complexity.as_deref() == value.as_str(),
+            "parent" => node.parent.as_deref() == value.as_str(),
+            _ => false,
+        };
+
+        if !is_noop {
+            effective.insert(key.clone(), value.clone());
+        }
+    }
+
+    // Handle _add_tags
+    if let Some(add_tags_val) = updates_map.get("_add_tags") {
+        let add_tags = add_tags_val.as_array().ok_or_else(|| anyhow::anyhow!("_add_tags must be an array of strings"))?;
+        let new_tags: Vec<String> = add_tags
+            .iter()
+            .map(|v| v.as_str().map(String::from).ok_or_else(|| anyhow::anyhow!("_add_tags elements must be strings")))
+            .collect::<anyhow::Result<Vec<String>>>()?
+            .into_iter()
+            .filter(|t| !node.tags.contains(t))
+            .collect();
+        if !new_tags.is_empty() {
+            let mut all_tags = node.tags.clone();
+            all_tags.extend(new_tags);
+            effective.insert(
+                "tags".to_string(),
+                serde_json::Value::Array(all_tags.into_iter().map(serde_json::Value::String).collect()),
+            );
+        }
+    }
+
+    // Handle _remove_tags
+    if let Some(remove_tags_val) = updates_map.get("_remove_tags") {
+        let remove_tags = remove_tags_val.as_array().ok_or_else(|| anyhow::anyhow!("_remove_tags must be an array of strings"))?;
+        let remove_set: std::collections::HashSet<&str> = remove_tags
+            .iter()
+            .map(|v| v.as_str().ok_or_else(|| anyhow::anyhow!("_remove_tags elements must be strings")))
+            .collect::<anyhow::Result<std::collections::HashSet<&str>>>()?;
+        if node.tags.iter().any(|t| remove_set.contains(t.as_str())) {
+            let remaining: Vec<String> = node
+                .tags
+                .iter()
+                .filter(|t| !remove_set.contains(t.as_str()))
+                .cloned()
+                .collect();
+            effective.insert(
+                "tags".to_string(),
+                serde_json::Value::Array(remaining.into_iter().map(serde_json::Value::String).collect()),
+            );
+        }
+    }
+
+    // Handle _add_depends_on
+    if let Some(add_deps_val) = updates_map.get("_add_depends_on") {
+        let add_deps = add_deps_val.as_array().ok_or_else(|| anyhow::anyhow!("_add_depends_on must be an array of strings"))?;
+        let new_deps: Vec<String> = add_deps
+            .iter()
+            .map(|v| v.as_str().map(String::from).ok_or_else(|| anyhow::anyhow!("_add_depends_on elements must be strings")))
+            .collect::<anyhow::Result<Vec<String>>>()?
+            .into_iter()
+            .filter(|d| !node.depends_on.contains(d))
+            .collect();
+        if !new_deps.is_empty() {
+            let mut all_deps = node.depends_on.clone();
+            all_deps.extend(new_deps);
+            effective.insert(
+                "depends_on".to_string(),
+                serde_json::Value::Array(all_deps.into_iter().map(serde_json::Value::String).collect()),
+            );
+        }
+    }
+
+    // Handle _remove_depends_on
+    if let Some(remove_deps_val) = updates_map.get("_remove_depends_on") {
+        let remove_deps = remove_deps_val.as_array().ok_or_else(|| anyhow::anyhow!("_remove_depends_on must be an array of strings"))?;
+        let remove_set: std::collections::HashSet<&str> = remove_deps
+            .iter()
+            .map(|v| v.as_str().ok_or_else(|| anyhow::anyhow!("_remove_depends_on elements must be strings")))
+            .collect::<anyhow::Result<std::collections::HashSet<&str>>>()?;
+        if node.depends_on.iter().any(|d| remove_set.contains(d.as_str())) {
+            let remaining: Vec<String> = node
+                .depends_on
+                .iter()
+                .filter(|d| !remove_set.contains(d.as_str()))
+                .cloned()
+                .collect();
+            effective.insert(
+                "depends_on".to_string(),
+                serde_json::Value::Array(remaining.into_iter().map(serde_json::Value::String).collect()),
+            );
+        }
+    }
+
+    // Handle superseded_by
+    if let Some(superseded_by) = updates_map.get("superseded_by") {
+        effective.insert("superseded_by".to_string(), superseded_by.clone());
+        if !effective.contains_key("status") {
+            effective.insert(
+                "status".to_string(),
+                serde_json::Value::String("done".to_string()),
+            );
+        }
+    }
+
+    Ok(effective)
+}

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -233,7 +233,7 @@ impl PkbSearchServer {
             ),
             data: None,
         })?;
-        if ev.trim().is_empty() {
+        if !ev.chars().any(|c| !c.is_whitespace()) {
             return Err(McpError {
                 code: ErrorCode::INVALID_PARAMS,
                 message: Cow::from(
@@ -1509,12 +1509,14 @@ impl PkbSearchServer {
                 "create_task invocation"
             );
             if !unknown.is_empty() {
-                tracing::warn!(
-                    target: "pkb::create_task",
-                    unknown_keys = ?unknown,
-                    "create_task received unknown keys — these fields will NOT be written. \
-                     Pass them via update_task or extend the create_task schema."
-                );
+                return Err(McpError {
+                    code: ErrorCode::INVALID_PARAMS,
+                    message: std::borrow::Cow::from(format!(
+                        "Unknown keys in create_task: {:?}. Pass them via update_task or extend the create_task schema.",
+                        unknown
+                    )),
+                    data: None,
+                });
             }
         }
 
@@ -4149,6 +4151,39 @@ impl PkbSearchServer {
             title_to_id.insert(title_lower, id);
         }
 
+        let mut unresolvable = Vec::new();
+        {
+            let graph = self.graph.read();
+            for subtask in subtasks.iter() {
+                if let Some(deps) = subtask.get("depends_on").and_then(|v| v.as_array()) {
+                    for dep_val in deps {
+                        if let Some(dep) = dep_val.as_str() {
+                            if dep.starts_with('$') {
+                                if let Ok(idx) = dep[1..].parse::<usize>() {
+                                    if idx == 0 || idx > subtask_ids.len() {
+                                        unresolvable.push(dep.to_string());
+                                    }
+                                } else {
+                                    unresolvable.push(dep.to_string());
+                                }
+                            } else if !title_to_id.contains_key(&dep.to_lowercase()) {
+                                if graph.resolve(dep).is_none() {
+                                    unresolvable.push(dep.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if !unresolvable.is_empty() {
+            return Err(McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: std::borrow::Cow::from(format!("Unresolvable sibling references in decompose_task: {:?}", unresolvable)),
+                data: None,
+            });
+        }
+
         let mut created: Vec<(String, String)> = Vec::new();
         static ID_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
             regex::Regex::new(r"^([a-z]+-[0-9a-f]{8})").expect("valid static regex")
@@ -4922,9 +4957,19 @@ impl PkbSearchServer {
         // Validate parent change: reject if the new parent does not exist
         // (task-89b2af87) AND reject if the change would create a cycle.
         if let Some(new_parent_val) = updates.get("parent") {
-            // Treat null / empty string as "clear parent" — no validation needed.
+            // Treat null / empty string as "clear parent"
             let new_parent = new_parent_val.as_str().unwrap_or("").trim();
-            if !new_parent.is_empty() {
+            if new_parent.is_empty() {
+                let unparent = args.get("unparent").and_then(|v| v.as_bool()).unwrap_or(false);
+                let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
+                if !unparent && !force {
+                    return Err(McpError {
+                        code: ErrorCode::INVALID_PARAMS,
+                        message: std::borrow::Cow::from("To remove a task's parent, pass unparent=true explicitly."),
+                        data: None,
+                    });
+                }
+            } else {
                 let allow_missing = args
                     .get("allow_missing_parent")
                     .and_then(|v| v.as_bool())
@@ -5020,7 +5065,7 @@ impl PkbSearchServer {
                 .get("completion_evidence")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            if evidence.trim().is_empty() {
+            if !evidence.chars().any(|c| !c.is_whitespace()) {
                 return Err(McpError {
                     code: ErrorCode::INVALID_PARAMS,
                     message: Cow::from(
@@ -5043,11 +5088,25 @@ impl PkbSearchServer {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
-        let update_map: std::collections::HashMap<String, serde_json::Value> = updates
-            .iter()
-            .filter(|(k, _)| k.as_str() != "completion_evidence")
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+        let update_map = {
+            let graph = self.graph.read();
+            let node = graph.resolve(&canonical_id).ok_or_else(|| McpError {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: std::borrow::Cow::from(format!("Failed to resolve canonical id: {canonical_id}")),
+                data: None,
+            })?;
+            let mut filtered_updates = serde_json::Map::new();
+            for (k, v) in &updates {
+                if k != "completion_evidence" && k != "pr_url" {
+                    filtered_updates.insert(k.clone(), v.clone());
+                }
+            }
+            crate::document_crud::expand_special_update_keys(&node, &filtered_updates).map_err(|e| McpError {
+                code: ErrorCode::INVALID_PARAMS,
+                message: std::borrow::Cow::from(format!("Invalid updates: {e}")),
+                data: None,
+            })?
+        };
 
         // Per-phase timing for write-path perf investigation (task-a4dcc039).
         // Emitted at debug; set RUST_LOG=mem::mcp_server=debug to observe.
@@ -5117,7 +5176,7 @@ impl PkbSearchServer {
     fn handle_batch_update(&self, args: &JsonValue) -> Result<CallToolResult, McpError> {
         let filters = crate::batch_ops::filters::parse_filter_set(args);
         let updates = args.get("updates").cloned().unwrap_or(JsonValue::Object(serde_json::Map::new()));
-        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(true);
 
         if filters.is_empty() && updates.as_object().map(|m| m.is_empty()).unwrap_or(true) {
             return Err(McpError {
@@ -5151,7 +5210,7 @@ impl PkbSearchServer {
             .to_string();
 
         let filters = crate::batch_ops::filters::parse_filter_set(args);
-        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(true);
 
         let graph = self.graph.read();
         let summary = crate::batch_ops::reparent::batch_reparent(
@@ -5219,7 +5278,7 @@ impl PkbSearchServer {
             });
         }
 
-        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(true);
 
         let summary =
             crate::document_crud::merge_node(&self.pkb_root, &source_ids, &canonical_id, dry_run)
@@ -5402,7 +5461,7 @@ impl PkbSearchServer {
             .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
             .unwrap_or_default();
 
-        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(false);
+        let dry_run = args.get("dry_run").and_then(|v| v.as_bool()).unwrap_or(true);
 
         if merge_ids.is_empty() {
             return Err(McpError {
@@ -5837,13 +5896,7 @@ impl PkbSearchServer {
     fn dispatch_tool_sync(&self, name: &str, args: &JsonValue) -> Result<CallToolResult, McpError> {
         match name {
             // --- Consolidated Tools ---
-            "create_document" => self.handle_create_document_consolidated(args),
-            "manage_task" => self.handle_manage_task_consolidated(args),
-            "pkb_explore" => self.handle_pkb_explore_consolidated(args),
-            "pkb_batch" => self.handle_pkb_batch_consolidated(args),
-            "pkb_stats" => self.handle_pkb_stats_consolidated(args),
-            "pkb_tool_help" => self.handle_pkb_tool_help(args),
-
+                                                                        
             // --- Legacy / Granular Tools ---
             "search" => self.handle_pkb_search(args),
             "get_document" => self.handle_get_document(args),
@@ -5852,8 +5905,7 @@ impl PkbSearchServer {
             "get_network_metrics" => self.handle_get_network_metrics(args),
             "create_task" => self.handle_create_task(args),
             "claim_task" => self.handle_claim_task(args),
-            "create_subtask" => self.handle_create_subtask(args),
-            "create_memory" => self.handle_create_memory(args),
+                        "create_memory" => self.handle_create_memory(args),
             "create" => self.handle_create_document(args),
             "append" => self.handle_append_to_document(args),
             "update_body" => self.handle_update_body(args),
@@ -5863,8 +5915,7 @@ impl PkbSearchServer {
             "list_tasks" => self.handle_list_tasks(args),
             "get_task" => self.handle_get_task(args),
             "update_task" => self.handle_update_task(args),
-            "bulk_reparent" => self.handle_bulk_reparent(args),
-            "retrieve_memory" => self.handle_retrieve_memory(args),
+                        "retrieve_memory" => self.handle_retrieve_memory(args),
             "detect_weight_divergence" => self.handle_detect_weight_divergence(args),
             "search_by_tag" => self.handle_search_by_tag(args),
             "list_memories" => self.handle_list_memories(args),

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -4930,7 +4930,7 @@ impl PkbSearchServer {
         //   1. Nested: {"id": "...", "updates": {"status": "done"}}
         //   2. Flat:   {"id": "...", "status": "done"}
         // If `updates` is present, it wins. Otherwise collect top-level fields.
-        const ROUTING_KEYS: &[&str] = &["id", "updates", "recursive"];
+        const ROUTING_KEYS: &[&str] = &["id", "updates", "recursive", "unparent", "force", "allow_missing_parent"];
         let updates: serde_json::Map<String, serde_json::Value> =
             if let Some(nested) = args.get("updates").and_then(|v| v.as_object()) {
                 nested.clone()
@@ -5097,7 +5097,7 @@ impl PkbSearchServer {
             })?;
             let mut filtered_updates = serde_json::Map::new();
             for (k, v) in &updates {
-                if k != "completion_evidence" && k != "pr_url" {
+                if k != "completion_evidence" {
                     filtered_updates.insert(k.clone(), v.clone());
                 }
             }
@@ -6591,7 +6591,7 @@ impl PkbSearchServer {
                         "title_contains": { "type": "string", "description": "Filter: title substring (case-insensitive)" },
                         "weight_gte": { "type": "integer", "description": "Filter: downstream weight >= N" },
                         "updates": { "type": "object", "description": "Fields to set (null to remove). Special keys: _add_tags, _remove_tags, _add_depends_on, _remove_depends_on" },
-                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: false)" }
+                        "dry_run": { "type": "boolean", "description": "Preview only (default: true — must explicitly set false to execute)" }
                     },
                     "required": ["updates"]
                 }))
@@ -6614,7 +6614,7 @@ impl PkbSearchServer {
                         "tags": { "type": "array", "items": { "type": "string" }, "description": "Filter: has ALL listed tags" },
                         "title_contains": { "type": "string", "description": "Filter: title substring" },
                         "new_parent": { "type": "string", "description": "ID of new parent (flexible resolution)" },
-                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: false)" }
+                        "dry_run": { "type": "boolean", "description": "Preview only (default: true — must explicitly set false to execute)" }
                     },
                     "required": ["new_parent"]
                 }))
@@ -6734,7 +6734,7 @@ impl PkbSearchServer {
                     "properties": {
                         "canonical": { "type": "string", "description": "ID of the task to keep" },
                         "merge_ids": { "type": "array", "items": { "type": "string" }, "description": "IDs of duplicates to merge into canonical" },
-                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: false)" }
+                        "dry_run": { "type": "boolean", "description": "Preview only (default: true — must explicitly set false to execute)" }
                     },
                     "required": ["canonical", "merge_ids"]
                 }))
@@ -6750,7 +6750,7 @@ impl PkbSearchServer {
                     "properties": {
                         "canonical_id": { "type": "string", "description": "ID of the node to merge into (must already exist)" },
                         "source_ids": { "type": "array", "items": { "type": "string" }, "description": "IDs of nodes to merge into canonical and archive" },
-                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: false)" }
+                        "dry_run": { "type": "boolean", "description": "Preview only (default: true — must explicitly set false to execute)" }
                     },
                     "required": ["canonical_id", "source_ids"]
                 }))
@@ -8005,7 +8005,8 @@ mod batch_finalize_tests {
         // Run a batch update that flips status to "blocked".
         let args = json!({
             "ids": task_ids,
-            "updates": { "status": "blocked" }
+            "updates": { "status": "blocked" },
+            "dry_run": false
         });
         let result = server.handle_batch_update(&args).expect("batch_update");
         let text = result

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -5895,9 +5895,6 @@ impl PkbSearchServer {
 
     fn dispatch_tool_sync(&self, name: &str, args: &JsonValue) -> Result<CallToolResult, McpError> {
         match name {
-            // --- Consolidated Tools ---
-                                                                        
-            // --- Legacy / Granular Tools ---
             "search" => self.handle_pkb_search(args),
             "get_document" => self.handle_get_document(args),
             "list_documents" => self.handle_list_documents(args),
@@ -5905,7 +5902,7 @@ impl PkbSearchServer {
             "get_network_metrics" => self.handle_get_network_metrics(args),
             "create_task" => self.handle_create_task(args),
             "claim_task" => self.handle_claim_task(args),
-                        "create_memory" => self.handle_create_memory(args),
+            "create_memory" => self.handle_create_memory(args),
             "create" => self.handle_create_document(args),
             "append" => self.handle_append_to_document(args),
             "update_body" => self.handle_update_body(args),
@@ -5915,7 +5912,7 @@ impl PkbSearchServer {
             "list_tasks" => self.handle_list_tasks(args),
             "get_task" => self.handle_get_task(args),
             "update_task" => self.handle_update_task(args),
-                        "retrieve_memory" => self.handle_retrieve_memory(args),
+            "retrieve_memory" => self.handle_retrieve_memory(args),
             "detect_weight_divergence" => self.handle_detect_weight_divergence(args),
             "search_by_tag" => self.handle_search_by_tag(args),
             "list_memories" => self.handle_list_memories(args),
@@ -5959,18 +5956,7 @@ impl ServerHandler for PkbSearchServer {
         let tool_name = request.name.clone();
         let args = Self::args_to_value(request.arguments);
 
-        // For consolidated tools, build a granular name for telemetry
-        let effective_name: String = match &*tool_name {
-            "manage_task" | "pkb_explore" | "pkb_batch" | "pkb_stats" | "create_document" => {
-                let sub = args
-                    .get("action")
-                    .or_else(|| args.get("type"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
-                format!("{tool_name}/{sub}")
-            }
-            other => other.to_string(),
-        };
+        let effective_name = tool_name.to_string();
 
         let this = self.clone();
         async move {
@@ -6199,21 +6185,6 @@ impl PkbSearchServer {
             )
             .with_title("Create Task"),
             Tool::new(
-                "create_subtask",
-                "Create a numbered sub-task attached to a parent task. Sub-tasks use dot-notation IDs (e.g. proj.1) and appear as a checklist when the parent is retrieved. Use for fine-grained completion tracking.",
-                serde_json::from_value::<JsonObject>(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "parent_id": { "type": "string", "description": "ID of the parent task (e.g. proj-deadbeef)" },
-                        "title": { "type": "string", "description": "Sub-task title" },
-                        "body": { "type": "string", "description": "Optional markdown body" }
-                    },
-                    "required": ["parent_id", "title"]
-                }))
-                .unwrap(),
-            )
-            .with_title("Create Sub-task"),
-            Tool::new(
                 "claim_task",
                 "Instantiate a template task. When called on a `type: template` node, creates a \
                  datestamped instance (<slug>-<YYYYMMDD>-<HHMM>-<host>.md) and returns it via \
@@ -6425,22 +6396,6 @@ impl PkbSearchServer {
                 .unwrap(),
             )
             .with_title("Update Task")
-            .with_annotations(ToolAnnotations::new().idempotent(true)),
-            Tool::new(
-                "bulk_reparent",
-                "Set a new parent for all documents matching a pattern. Skips files already parented correctly. Dry run by default.",
-                serde_json::from_value::<JsonObject>(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "pattern": { "type": "string", "description": "Directory path or glob pattern (e.g. 'archive/', 'tasks/*.md'). Relative to PKB root." },
-                        "parent_id": { "type": "string", "description": "Parent ID to set on matching files" },
-                        "dry_run": { "type": "boolean", "description": "Preview changes without writing (default: true). Set to false to apply.", "default": true }
-                    },
-                    "required": ["pattern", "parent_id"]
-                }))
-                .unwrap(),
-            )
-            .with_title("Bulk Reparent Tasks")
             .with_annotations(ToolAnnotations::new().idempotent(true)),
             Tool::new(
                 "retrieve_memory",
@@ -6863,84 +6818,6 @@ impl PkbSearchServer {
             )
             .with_title("Tool Usage Stats")
             .with_annotations(ToolAnnotations::new().read_only(true)),
-            // --- Consolidated (Progressive Disclosure) Tools ---
-            Tool::new(
-                "create_document",
-                "Create a new PKB node (task, subtask, memory, note, goal, project, epic). Dispatches on `type`.",
-                serde_json::from_value::<JsonObject>(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "type": { "type": "string", "enum": ["task", "subtask", "memory", "note", "goal", "project", "epic"] },
-                        "title": { "type": "string" },
-                        "parent": { "type": "string", "description": "Parent ID (required for subtask)" },
-                        "fields": { "type": "object", "description": "Metadata: priority, tags, depends_on, assignee, etc." },
-                        "body": { "type": "string" }
-                    },
-                    "required": ["type", "title"]
-                }))
-                .unwrap(),
-            )
-            .with_title("Create Document"),
-            Tool::new(
-                "manage_task",
-                "Lifecycle management for tasks: update, complete, release, or decompose.",
-                serde_json::from_value::<JsonObject>(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "id": { "type": "string" },
-                        "action": { "type": "string", "enum": ["update", "complete", "release", "decompose"] },
-                        "params": { "type": "object", "description": "Action-specific parameters (e.g. updates, summary, pr_url, subtasks)" }
-                    },
-                    "required": ["id", "action"]
-                }))
-                .unwrap(),
-            )
-            .with_title("Manage Task")
-            .with_annotations(ToolAnnotations::new().idempotent(true)),
-            Tool::new(
-                "pkb_explore",
-                "Explore graph relationships: context, trace, tree, children, metrics.",
-                serde_json::from_value::<JsonObject>(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "id": { "type": "string" },
-                        "action": { "type": "string", "enum": ["context", "trace", "tree", "children", "metrics"] },
-                        "params": { "type": "object", "description": "Action-specific: e.g. {to: 'ID'} for trace, {recursive: true} for children" }
-                    },
-                    "required": ["id", "action"]
-                }))
-                .unwrap(),
-            )
-            .with_title("PKB Graph Explorer")
-            .with_annotations(ToolAnnotations::new().read_only(true)),
-            Tool::new(
-                "pkb_batch",
-                "Bulk operations: update, reparent, archive, merge, node_merge, epics, reclassify, duplicates, orphans.",
-                serde_json::from_value::<JsonObject>(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "action": { "type": "string", "enum": ["update", "reparent", "archive", "merge", "node_merge", "epics", "reclassify", "duplicates", "orphans"] },
-                        "params": { "type": "object", "description": "Filters, updates, new_parent, merge_ids, etc." }
-                    },
-                    "required": ["action"]
-                }))
-                .unwrap(),
-            )
-            .with_title("PKB Batch Operations")
-            .with_annotations(ToolAnnotations::new().destructive(true)),
-            Tool::new(
-                "pkb_stats",
-                "System and graph status: summary, graph_stats, graph_json, tool_stats, status, divergence.",
-                serde_json::from_value::<JsonObject>(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "action": { "type": "string", "enum": ["summary", "graph_stats", "graph_json", "tool_stats", "status", "divergence"] }
-                    }
-                }))
-                .unwrap(),
-            )
-            .with_title("PKB Statistics")
-            .with_annotations(ToolAnnotations::new().read_only(true)),
             Tool::new(
                 "status",
                 "Report mem build identity: package version, embedded git describe, and build profile. Use to confirm which binary is running.",
@@ -6951,20 +6828,6 @@ impl PkbSearchServer {
                 .unwrap(),
             )
             .with_title("Build Status")
-            .with_annotations(ToolAnnotations::new().read_only(true)),
-            Tool::new(
-                "pkb_tool_help",
-                "Get detailed schema and examples for consolidated tools.",
-                serde_json::from_value::<JsonObject>(serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "tool": { "type": "string" },
-                        "action": { "type": "string" }
-                    }
-                }))
-                .unwrap(),
-            )
-            .with_title("PKB Tool Help")
             .with_annotations(ToolAnnotations::new().read_only(true)),
         ]
     }


### PR DESCRIPTION
Implements Fixes 1, 2, 3, 5, 6 from crud redesign spec and surface reduction (removes deprecated wrapper tools).

Fix 4 (partial-failure reporting on recursive close in complete_task/release_task) is deferred to a follow-up PR.